### PR TITLE
fixed parsing tree with single quoted labels

### DIFF
--- a/R/read.tree.R
+++ b/R/read.tree.R
@@ -26,7 +26,7 @@ read.tree <- function(file = "", text = NULL, tree.names = NULL, skip = 0,
     }
 
     tree <- gsub("[ \t]", "", tree)
-    tree <- gsub("''", "", tree)
+    tree <- gsub("'", "", tree)
 
     single_quotes <- function(x, start = 1L) {
         z <- unlist(gregexpr("'", x))


### PR DESCRIPTION
fixed the issue reported in <https://github.com/YuLab-SMU/treeio/pull/41> and <https://github.com/emmanuelparadis/ape/issues/1>.