### PR TITLE
Enable `type = "s"` in `ltt.plot.coords()`

### DIFF
--- a/R/ltt.plot.R
+++ b/R/ltt.plot.R
@@ -7,8 +7,11 @@
 ## This file is part of the R-package `ape'.
 ## See the file ../COPYING for licensing issues.
 
-ltt.plot.coords <- function(phy, backward = TRUE, tol = 1e-6)
+ltt.plot.coords <- function(phy, backward = TRUE, tol = 1e-6, type = "S")
 {
+    if (!type %in% c("S", "s")) {
+        stop("argument type be \"S\" or \"s\".")
+    }
     if (has.singles(phy)) phy <- collapse.singles(phy, root.edge = TRUE) # added 2021-03-01
     if (is.ultrametric(phy, tol)) {
         if (is.binary.phylo(phy)) {
@@ -29,27 +32,24 @@ ltt.plot.coords <- function(phy, backward = TRUE, tol = 1e-6)
         m <- phy$Nnode
         ROOT <- n + 1L
         event <- time.event <- numeric(n + m)
-
         time.event[ROOT] <- 0
         phy <- reorder(phy)
-
         for (i in 1:nrow(phy$edge))
             time.event[phy$edge[i, 2]] <- time.event[phy$edge[i, 1]] + phy$edge.length[i]
-
         present <- max(time.event)
         event[1:n] <- -1
         event[ROOT:(n + m)] <- 1
-
+        
         ## delete the events that are too close to present:
         past.event <- present - time.event > tol
         event <- event[past.event]
         time.event <- time.event[past.event]
-
+        
         ## reorder wrt time:
         o <- order(time.event)
         time.event <- time.event[o]
         event <- event[o]
-
+        
         time <- c(time.event - present, 0)
         N <- c(1, event)
     }
@@ -59,6 +59,9 @@ ltt.plot.coords <- function(phy, backward = TRUE, tol = 1e-6)
         N <- c(1, N)
     }
     if (!backward) time <- time - time[1]
+    if (type == "s") {
+        N <- c(N[2:length(N)], N[length(N)])
+    }
     cbind(time, N)
 }
 
@@ -67,78 +70,78 @@ ltt.plot <- function(phy, xlab = "Time", ylab = "N",
 {
     if (!inherits(phy, "phylo"))
         stop("object \"phy\" is not of class \"phylo\"")
-
-    xy <- ltt.plot.coords(phy, backward, tol)
-
+    
+    xy <- ltt.plot.coords(phy, backward, tol, type = "S")
+    
     plot.default(xy, xlab = xlab, ylab = ylab, xaxs = "r",
                  yaxs = "r", type = "S", ...)
 }
 
 ltt.lines <- function(phy, backward = TRUE, tol = 1e-6, ...)
 {
-    xy <- ltt.plot.coords(phy, backward, tol)
+    xy <- ltt.plot.coords(phy, backward, tol, type = "S")
     lines(xy, type = "S", ...)
 }
 
 mltt.plot <-
     function(phy, ..., dcol = TRUE, dlty = FALSE, legend = TRUE,
              xlab = "Time", ylab = "N", log = "", backward = TRUE, tol = 1e-6)
-{
-    if (inherits(phy, "phylo")) { # if a tree of class "phylo"
-        TREES <- list(ltt.plot.coords(phy, backward, tol))
-        names(TREES) <- deparse(substitute(phy))
-    } else { # a list of trees
-        TREES <- lapply(phy, ltt.plot.coords, backward = backward, tol = tol)
-        names(TREES) <- names(phy)
-        if (is.null(names(TREES)))
-            names(TREES) <-
+    {
+        if (inherits(phy, "phylo")) { # if a tree of class "phylo"
+            TREES <- list(ltt.plot.coords(phy, backward, tol, type = "S"))
+            names(TREES) <- deparse(substitute(phy))
+        } else { # a list of trees
+            TREES <- lapply(phy, ltt.plot.coords, backward = backward, tol = tol, type = "S")
+            names(TREES) <- names(phy)
+            if (is.null(names(TREES)))
+                names(TREES) <-
                 paste(deparse(substitute(phy)), "-", 1:length(TREES))
-    }
-    dts <- list(...)
-    n <- length(dts)
-    if (n) {
-        mc <- as.character(match.call())[-(1:2)]
-        nms <- mc[1:n]
-        for (i in 1:n) {
-            if (inherits(dts[[i]], "phylo")) {
-                a <- list(ltt.plot.coords(dts[[i]], backward, tol))
-                names(a) <- nms[i]
-            } else { # a list of trees
-                a <- lapply(dts[[i]], ltt.plot.coords, backward = backward, tol = tol)
-                names(a) <- names(dts[[i]])
-                if (is.null(names(a)))
-                    names(a) <- paste(deparse(substitute(phy)), "-", seq_along(a))
+        }
+        dts <- list(...)
+        n <- length(dts)
+        if (n) {
+            mc <- as.character(match.call())[-(1:2)]
+            nms <- mc[1:n]
+            for (i in 1:n) {
+                if (inherits(dts[[i]], "phylo")) {
+                    a <- list(ltt.plot.coords(dts[[i]], backward, tol, type = "S"))
+                    names(a) <- nms[i]
+                } else { # a list of trees
+                    a <- lapply(dts[[i]], ltt.plot.coords, backward = backward, tol = tol, type = "S")
+                    names(a) <- names(dts[[i]])
+                    if (is.null(names(a)))
+                        names(a) <- paste(deparse(substitute(phy)), "-", seq_along(a))
+                }
+                TREES <- c(TREES, a)
             }
-            TREES <- c(TREES, a)
         }
-    }
-    n <- length(TREES)
-    range.each.tree <- sapply(TREES, function(x) range(x[, 1]))
-    xl <- range(range.each.tree)
-    yl <- c(1, max(sapply(TREES, function(x) max(x[, 2]))))
-
-    ## if backward is FALSE, we have to rescale the time scales of each tree:
-    if (!backward) {
-        for (i in seq_along(TREES)) {
-            tmp <- TREES[[i]]
-            tmp[, 1] <- tmp[, 1] + xl[2] - range.each.tree[2, i]
-            TREES[[i]] <- tmp
+        n <- length(TREES)
+        range.each.tree <- sapply(TREES, function(x) range(x[, 1]))
+        xl <- range(range.each.tree)
+        yl <- c(1, max(sapply(TREES, function(x) max(x[, 2]))))
+        
+        ## if backward is FALSE, we have to rescale the time scales of each tree:
+        if (!backward) {
+            for (i in seq_along(TREES)) {
+                tmp <- TREES[[i]]
+                tmp[, 1] <- tmp[, 1] + xl[2] - range.each.tree[2, i]
+                TREES[[i]] <- tmp
+            }
         }
+        
+        plot.default(NA, type = "n", xlim = xl, ylim = yl, xaxs = "r",
+                     yaxs = "r", xlab = xlab, ylab = ylab, log = log)
+        
+        lty <- if (!dlty) rep(1, n) else 1:n
+        col <- if (!dcol) rep(1, n) else topo.colors(n)
+        
+        for (i in 1:n)
+            lines(TREES[[i]], col = col[i], lty = lty[i], type = "S")
+        
+        if (legend)
+            legend(xl[1], yl[2], legend = names(TREES),
+                   lty = lty, col = col, bty = "n")
     }
-
-    plot.default(NA, type = "n", xlim = xl, ylim = yl, xaxs = "r",
-                 yaxs = "r", xlab = xlab, ylab = ylab, log = log)
-
-    lty <- if (!dlty) rep(1, n) else 1:n
-    col <- if (!dcol) rep(1, n) else topo.colors(n)
-
-    for (i in 1:n)
-        lines(TREES[[i]], col = col[i], lty = lty[i], type = "S")
-
-    if (legend)
-        legend(xl[1], yl[2], legend = names(TREES),
-               lty = lty, col = col, bty = "n")
-}
 
 ltt.coplot <- function(phy, backward = TRUE, ...)
 {

--- a/man/ltt.plot.Rd
+++ b/man/ltt.plot.Rd
@@ -17,7 +17,7 @@ mltt.plot(phy, ..., dcol = TRUE, dlty = FALSE, legend = TRUE,
           xlab = "Time", ylab = "N", log = "", backward = TRUE,
           tol = 1e-6)
 ltt.coplot(phy, backward = TRUE, ...)
-ltt.plot.coords(phy, backward = TRUE, tol = 1e-6)
+ltt.plot.coords(phy, backward = TRUE, tol = 1e-6, type = "S")
 }
 \arguments{
   \item{phy}{an object of class \code{"phylo"}; this could be an object
@@ -44,6 +44,8 @@ ltt.plot.coords(phy, backward = TRUE, tol = 1e-6)
   \item{log}{a character string specifying which axis(es) to be
     log-transformed; must be one of the followings: \code{""},
     \code{"x"}, \code{"y"}, or \code{"xy"}.}
+  \item{type}{either \code{"S"} or \code{"s"}, the preferred type of step function, corresponding
+  to argument \code{type} of base function \code{plot()}. See section "Value" below.}
 }
 \details{
   \code{ltt.plot} does a simple lineages through time (LTT)
@@ -87,11 +89,10 @@ ltt.plot.coords(phy, backward = TRUE, tol = 1e-6)
 }
 \value{
   \code{ltt.plot.coords} returns a two-column matrix with the time
-  points and the number of lineages, respectively. The \eqn{i}th value
-  of the second column is the number of lineages for the interval
-  defined by the \eqn{(i - 1)}th and the \eqn{i}th values of the first
-  column. These are then plotted with the option \code{type = "S"} by
-  the other functions.
+  points and the number of lineages, respectively. 
+  \code{type = "S"} returns the number of lineages to the left of (or "up to") 
+  the corresponding point in time, while \code{type = "s"} returns the number of
+  lineages to the right of this point (i.e, between that time and the next).
 }
 \references{
   Harvey, P. H., May, R. M. and Nee, S. (1994) Phylogenies without


### PR DESCRIPTION
Added an argument to `ltt.plot.coords()` so that users can choose whether the output matrix gives the number of lineages to the left (`type = "S"`) or right (`type = "s"`) of the time given in `time`.
See #3 