### PR TITLE
fix some edge cases for ONEwise

### DIFF
--- a/R/dist.topo.R
+++ b/R/dist.topo.R
@@ -341,12 +341,15 @@ postprocess.prop.part <- function(x)
 ### changed to 1:2.
 ONEwise <- function(x)
 {
-    v <- seq_along(x[[1L]])
-    for (i in 2:length(x)) {
-        y <- x[[i]]
-        if (y[1] != 1) x[[i]] <- v[-y]
-    }
-    x
+  nTips <- length(attr(x, "labels"))
+  v <- seq_len(nTips)
+  l <- which(lengths(x)==0)
+  if(any(l)) for(i in l)x[[i]] <- v
+  for (i in seq_along(x)) {
+    y <- x[[i]]
+    if (y[1] != 1) x[[i]] <- v[-y]
+  }
+  x
 }
 
 ### This function changes an object of class "prop.part" so that they


### PR DESCRIPTION
Hi @emmanuelparadis,  
just some fixes to allow using ONEwise on splits elements. 
``` 
> library(ape)
> tree <- rtree(6, rooted = FALSE)
> library(magrittr)
> bp1 <- prop.part(tree) %>% ONEwise()
> bp2 <- prop.part(tree) %>% SHORTwise() %>% ONEwise()
> all.equal(bp1, bp2)
[1] TRUE
```
Have a nice weekend and good luck with the submission 
Klaus
