### PR TITLE
fixed bug of as.phylo for multiple class object

### DIFF
--- a/R/as.phylo.R
+++ b/R/as.phylo.R
@@ -29,7 +29,8 @@ new2old.phylo <- function(phy)
 
 as.phylo <- function (x, ...)
 {
-    if (identical(class(x), "phylo")) return(x)
+    ## if (identical(class(x), "phylo")) return(x)
+    if (inherits(x, "phylo")) return(x)
     UseMethod("as.phylo")
 }
 


### PR DESCRIPTION

```r
> tr = rtree(10)
> chr = chronos(tr)
> class(chr)
[1] "chronos" "phylo"  
```

Here is an example, and we would expect `as.phylo(chr)` return itself. 

The current implementation will throw the following error:

>> as.phylo(chr)
>Error in UseMethod("as.phylo") : 
>  no applicable method for 'as.phylo' applied to an object of class "c('chronos', 'phylo')"

This PR will fix it. 