### PR TITLE
Allow styling of nodes within `phylogram.plot()`

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,2 @@
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 # Session Data files
 .RData
+*.Rproj
 
 # User-specific files
 .Ruserdata
@@ -37,6 +38,10 @@ vignettes/*.pdf
 
 # R Environment Variables
 .Renviron
+
+# Compiled files
+*.dll
+*.o
 
 # back-up files created by Emacs
 *.R~

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ape
-Version: 5.5-1
-Date: 2021-07-07
+Version: 5.5-2
+Date: 2021-08-07
 Title: Analyses of Phylogenetics and Evolution
 Authors@R: c(person("Emmanuel", "Paradis", role = c("aut", "cre", "cph"), email = "Emmanuel.Paradis@ird.fr", comment = c(ORCID = "0000-0003-3092-2199")),
   person("Simon", "Blomberg", role = c("aut", "cph"), comment = c(ORCID = "0000-0003-1062-0839")),

--- a/R/plot.phylo.R
+++ b/R/plot.phylo.R
@@ -21,7 +21,7 @@ plot.phylo <-
 {
     Ntip <- length(x$tip.label)
     if (Ntip < 2) {
-        warning("found less than 2 tips in the tree")
+        warning("found fewer than 2 tips in the tree")
         return(NULL)
     }
 #    if (any(tabulate(x$edge[, 1]) == 1))

--- a/R/plot.phylo.R
+++ b/R/plot.phylo.R
@@ -543,8 +543,8 @@ phylogram.plot <- function(edge, Ntip, Nnode, xx, yy, horizontal,
     }
 
     .style <- function (edge.style, node.style, stylePar) {
-        if (is.null(edge.style)) {
-            if (is.null(node.style)) {
+        if (missing(edge.style) || is.null(edge.style)) {
+            if (missing(node.style) || is.null(node.style)) {
                 return(.one.style(par(stylePar)))
             } else {
                 if (length(node.style) == 1L) {
@@ -554,7 +554,7 @@ phylogram.plot <- function(edge, Ntip, Nnode, xx, yy, horizontal,
                                 v = rep_len(node.style, Ntip + Nnode)))
                 }
             }
-        } else if (is.null(node.style)) {
+        } else if (missing(node.style) || is.null(node.style)) {
             if (length(edge.style) == 1L) {
                 return(.one.style(edge.style))
             } else {

--- a/R/plot.phylo.R
+++ b/R/plot.phylo.R
@@ -579,6 +579,9 @@ phylogram.plot <- function(edge, Ntip, Nnode, xx, yy, horizontal,
     edge.color <- colors$h
     edge.width <- widths$h
     edge.lty <- ltys$h
+    lty_str <- c("blank", "solid", "dashed", "dotted", "dotdash", "longdash", "twodash")
+    if(is.numeric(edge.lty)) edge.lty <- lty_str[edge.lty + 1]
+
     color.v <- colors$v[-seq_len(Ntip)]
     width.v <- widths$v[-seq_len(Ntip)]
     lty.v <- ltys$v[-seq_len(Ntip)]

--- a/R/plot.phylo.R
+++ b/R/plot.phylo.R
@@ -583,7 +583,8 @@ phylogram.plot <- function(edge, Ntip, Nnode, xx, yy, horizontal,
     width.v <- widths$v[-seq_len(Ntip)]
     lty.v <- ltys$v[-seq_len(Ntip)]
     DF <- data.frame(edge.color, edge.width, edge.lty, stringsAsFactors = FALSE)
-    DF <- DF[, c(is.null(node.color), is.null(edge.width), is.null(edge.lty))]
+    DF <- DF[, c(is.null(node.color), is.null(node.width), is.null(node.lty)),
+             drop = FALSE]
 
     for (i in seq_len(Nnode)) {
         br <- NodeInEdge1[[i]]

--- a/R/plot.phylo.R
+++ b/R/plot.phylo.R
@@ -589,13 +589,13 @@ phylogram.plot <- function(edge, Ntip, Nnode, xx, yy, horizontal,
     widths <- .style(edge.width, node.width, 'lwd')
     ltys <- .style(edge.lty, node.lty, 'lty')
 
-    DF <- data.frame(colors$h, widths$h, ltys$h, stringsAsFactors = FALSE)
+    edge.color <- colors$h
+    edge.width <- widths$h
+    edge.lty <- ltys$h
+    DF <- data.frame(edge.color, edge.width, edge.lty, stringsAsFactors = FALSE)
     color.v <- colors$v
     width.v <- widths$v
     lty.v <- ltys$v
-    edge.color <- colors$h
-    edge.width <- widths$h
-    edge.lth <- ltys$h
 
     for (i in seq_len(Nnode)) {
         br <- edgeChildren[[i]]

--- a/R/plot.phylo.R
+++ b/R/plot.phylo.R
@@ -530,17 +530,11 @@ phylogram.plot <- function(edge, Ntip, Nnode, xx, yy, horizontal,
     .edge.style <- function (edge.style, node.style) {
         # node.style is fixed
         node.style <- rep_len(node.style, Ntip + Nnode)
-        edge.style <- rep_len(edge.style, Nedge)
-
-        sapply(seq_len(Nedge), function (e) {
-            prnt <- e1[e]
-            chld <- e2[e]
-            if (node.style[prnt] == node.style[chld]) {
-                node.style[prnt]
-            } else {
-                edge.style[e]
-            }
-        })
+        if (is.null(edge.style)) {
+            sapply(seq_len(Nedge), function (e) node.style[e2[e]])
+        } else {
+            rep_len(edge.style, Nedge)
+        }
     }
 
     .node.style <- function (edge.style, node.style) {

--- a/R/plot.phylo.R
+++ b/R/plot.phylo.R
@@ -554,14 +554,14 @@ phylogram.plot <- function(edge, Ntip, Nnode, xx, yy, horizontal,
                     return(.one.style(node.style))
                 } else {
                     return(list(h = .edge.style(node.style),
-                                v = node.style))
+                                v = rep_len(node.style, Ntip + Nnode)))
                 }
             }
         } else if (is.null(node.style)) {
             if (length(edge.style) == 1L) {
                 return(.one.style(edge.style))
             } else {
-                return(list(h = edge.style,
+                return(list(h = rep_len(edge.style, Nedge),
                             v = .node.style(edge.style, par(stylePar))))
             }
         } else {
@@ -579,16 +579,20 @@ phylogram.plot <- function(edge, Ntip, Nnode, xx, yy, horizontal,
     edge.color <- colors$h
     edge.width <- widths$h
     edge.lty <- ltys$h
-    DF <- data.frame(edge.color, edge.width, edge.lty, stringsAsFactors = FALSE)
     color.v <- colors$v[-seq_len(Ntip)]
     width.v <- widths$v[-seq_len(Ntip)]
     lty.v <- ltys$v[-seq_len(Ntip)]
+    DF <- data.frame(edge.color, edge.width, edge.lty, stringsAsFactors = FALSE)
+    DF <- DF[, c(is.null(node.color), is.null(edge.width), is.null(edge.lty))]
 
     for (i in seq_len(Nnode)) {
         br <- NodeInEdge1[[i]]
         if (length(br) == 2) {
             A <- br[1]
             B <- br[2]
+
+            # We should draw a single line if at all possible, for the
+            # appearance of dotted / dashed line styles.
             if (any(DF[A, ] != DF[B, ])) {
                 ## add a new line:
                 y0v <- c(y0v, y0v[i])

--- a/R/plot.phylo.R
+++ b/R/plot.phylo.R
@@ -570,27 +570,26 @@ phylogram.plot <- function(edge, Ntip, Nnode, xx, yy, horizontal,
         }
     }
 
-
-    colors <- .style(edge.color, node.color, 'fg')
-    widths <- .style(edge.width, node.width, 'lwd')
-    ltys <- .style(edge.lty, node.lty, 'lty')
-
     .LtyToStr <- function (x) {
-        lty_str <- c("blank", "solid", "dashed", "dotted", "dotdash", "longdash", "twodash")
         if (is.numeric(x)) {
-            lty_str[x + 1L]
+            c("blank", "solid", "dashed", "dotted", "dotdash", "longdash",
+              "twodash")[x + 1L]
         } else {
             x
         }
     }
 
+    colors <- .style(edge.color, node.color, 'fg')
+    widths <- .style(edge.width, node.width, 'lwd')
+    ltys <- .style(.LtyToStr(edge.lty), .LtyToStr(node.lty), 'lty')
+
     edge.color <- colors$h
     edge.width <- widths$h
-    edge.lty <- .LtyToStr(ltys$h)
+    edge.lty <- ltys$h
 
     color.v <- colors$v[-seq_len(Ntip)]
     width.v <- widths$v[-seq_len(Ntip)]
-    lty.v <- .LtyToStr(ltys$v[-seq_len(Ntip)])
+    lty.v <- ltys$v[-seq_len(Ntip)]
 
     DF <- data.frame(edge.color, edge.width, edge.lty, stringsAsFactors = FALSE)
     DF <- DF[, c(is.null(node.color), is.null(node.width), is.null(node.lty)),

--- a/R/plot.phylo.R
+++ b/R/plot.phylo.R
@@ -568,7 +568,7 @@ phylogram.plot <- function(edge, Ntip, Nnode, xx, yy, horizontal,
                 if (length(node.style) == 1L) {
                     return(.one.style(node.style))
                 } else {
-                    return(list(h = .edge.style(par(stylePar), node.style),
+                    return(list(h = .edge.style(NULL, node.style),
                                 v = node.style))
                 }
             }
@@ -594,9 +594,9 @@ phylogram.plot <- function(edge, Ntip, Nnode, xx, yy, horizontal,
     edge.width <- widths$h
     edge.lty <- ltys$h
     DF <- data.frame(edge.color, edge.width, edge.lty, stringsAsFactors = FALSE)
-    color.v <- colors$v
-    width.v <- widths$v
-    lty.v <- ltys$v
+    color.v <- colors$v[-seq_len(Ntip)]
+    width.v <- widths$v[-seq_len(Ntip)]
+    lty.v <- ltys$v[-seq_len(Ntip)]
 
     for (i in seq_len(Nnode)) {
         br <- NodeInEdge1[[i]]

--- a/R/plot.phylo.R
+++ b/R/plot.phylo.R
@@ -488,8 +488,10 @@ plot.phylo <-
 }
 
 phylogram.plot <- function(edge, Ntip, Nnode, xx, yy, horizontal,
-                           edge.color, edge.width, edge.lty,
-                           node.color, node.width, node.lty)
+                           edge.color = NULL, edge.width = NULL,
+                           edge.lty = NULL,
+                           node.color = NULL, node.width = NULL,
+                           node.lty = NULL)
 {
     nodes <- Ntip + seq_len(Nnode)
     if (!horizontal) {
@@ -573,21 +575,25 @@ phylogram.plot <- function(edge, Ntip, Nnode, xx, yy, horizontal,
     widths <- .style(edge.width, node.width, 'lwd')
     ltys <- .style(edge.lty, node.lty, 'lty')
 
+    .LtyToStr <- function (x) {
+        lty_str <- c("blank", "solid", "dashed", "dotted", "dotdash", "longdash", "twodash")
+        if (is.numeric(x)) {
+            lty_str[x + 1L]
+        } else {
+            x
+        }
+    }
+
     edge.color <- colors$h
     edge.width <- widths$h
-    edge.lty <- ltys$h
-    lty_str <- c("blank", "solid", "dashed", "dotted", "dotdash", "longdash", "twodash")
-    if(is.numeric(edge.lty)) edge.lty <- lty_str[edge.lty + 1]
+    edge.lty <- .LtyToStr(ltys$h)
 
     color.v <- colors$v[-seq_len(Ntip)]
     width.v <- widths$v[-seq_len(Ntip)]
-    lty.v <- ltys$v[-seq_len(Ntip)]
-    if(is.numeric(lty.v)) lty.v <- lty_str[lty.v + 1]
+    lty.v <- .LtyToStr(ltys$v[-seq_len(Ntip)])
 
     DF <- data.frame(edge.color, edge.width, edge.lty, stringsAsFactors = FALSE)
-    DF <- DF[, c(missing(node.color) || is.null(node.color),
-                 missing(node.width) || is.null(node.width),
-                 missing(node.lty) || is.null(node.lty)),
+    DF <- DF[, c(is.null(node.color), is.null(node.width), is.null(node.lty)),
              drop = FALSE]
 
     for (i in seq_len(Nnode)) {

--- a/R/plot.phylo.R
+++ b/R/plot.phylo.R
@@ -583,7 +583,9 @@ phylogram.plot <- function(edge, Ntip, Nnode, xx, yy, horizontal,
     width.v <- widths$v[-seq_len(Ntip)]
     lty.v <- ltys$v[-seq_len(Ntip)]
     DF <- data.frame(edge.color, edge.width, edge.lty, stringsAsFactors = FALSE)
-    DF <- DF[, c(is.null(node.color), is.null(node.width), is.null(node.lty)),
+    DF <- DF[, c(missing(node.color) || is.null(node.color),
+                 missing(node.width) || is.null(node.width),
+                 missing(node.lty) || is.null(node.lty)),
              drop = FALSE]
 
     for (i in seq_len(Nnode)) {

--- a/R/plot.phylo.R
+++ b/R/plot.phylo.R
@@ -582,6 +582,8 @@ phylogram.plot <- function(edge, Ntip, Nnode, xx, yy, horizontal,
     color.v <- colors$v[-seq_len(Ntip)]
     width.v <- widths$v[-seq_len(Ntip)]
     lty.v <- ltys$v[-seq_len(Ntip)]
+    if(is.numeric(lty.v)) lty.v <- lty_str[lty.v + 1]
+
     DF <- data.frame(edge.color, edge.width, edge.lty, stringsAsFactors = FALSE)
     DF <- DF[, c(missing(node.color) || is.null(node.color),
                  missing(node.width) || is.null(node.width),

--- a/R/plot.phylo.R
+++ b/R/plot.phylo.R
@@ -509,7 +509,8 @@ phylogram.plot <- function(edge, Ntip, Nnode, xx, yy, horizontal,
     Nedge <- length(e1)
 
     ## store the index of each node in the 1st column of edge:
-    edgeChildren <- lapply(Ntip + seq_len(Nnode), function (j) e2[e1 == j])
+    NodeInEdge1 <- lapply(Ntip + seq_len(Nnode), function (j) which(e1 == j))
+    edgeChildren <- lapply(NodeInEdge1, function (nie) e2[nie])
     yv <- vapply(edgeChildren, function (i) range(yy[i]), double(2))
     y0v <- yv[1, ]
     y1v <- yv[2, ]
@@ -598,7 +599,7 @@ phylogram.plot <- function(edge, Ntip, Nnode, xx, yy, horizontal,
     lty.v <- ltys$v
 
     for (i in seq_len(Nnode)) {
-        br <- edgeChildren[[i]]
+        br <- NodeInEdge1[[i]]
         if (length(br) == 1) {
             A <- br[1]
             color.v[i] <- edge.color[A]

--- a/R/plot.phylo.R
+++ b/R/plot.phylo.R
@@ -114,14 +114,14 @@ plot.phylo <-
     ## 'z' is the tree in postorder order used in calls to .C
     z <- reorder(x, order = "postorder")
 
-if (phyloORclado) {
+    if (phyloORclado) {
         if (is.null(node.pos))
             node.pos <-
                 if (type == "cladogram" && !use.edge.length) 2 else 1
 
-        if (node.pos == 1)
+        if (node.pos == 1) {
             yy <- .nodeHeight(z$edge, Nedge, yy)
-        else {
+        } else {
           ## node_height_clado requires the number of descendants
           ## for each node, so we compute `xx' at the same time
           ans <- .C(node_height_clado, as.integer(Ntip),
@@ -136,52 +136,52 @@ if (phyloORclado) {
         } else  {
             xx <- .nodeDepthEdgelength(Ntip, Nnode, z$edge, Nedge, z$edge.length)
         }
-} else {
-    twopi <- 2 * pi
-    rotate.tree <- twopi * rotate.tree/360
+    } else {
+        twopi <- 2 * pi
+        rotate.tree <- twopi * rotate.tree/360
 
-    if (type != "unrooted") { # for "fan" and "radial" trees (open.angle)
-        ## if the tips are not in the same order in tip.label
-        ## and in edge[, 2], we must reorder the angles: we
-        ## use `xx' to store temporarily the angles
-        TIPS <- x$edge[which(x$edge[, 2] <= Ntip), 2]
-        xx <- seq(0, twopi * (1 - 1/Ntip) - twopi * open.angle/360,
-                  length.out = Ntip)
-        theta <- double(Ntip)
-        theta[TIPS] <- xx
-        theta <- c(theta, numeric(Nnode))
-    }
-
-    switch(type, "fan" = {
-        theta <- .nodeHeight(z$edge, Nedge, theta)
-        if (use.edge.length) {
-            r <- .nodeDepthEdgelength(Ntip, Nnode, z$edge, Nedge, z$edge.length)
-        } else {
-            r <- .nodeDepth(Ntip, Nnode, z$edge, Nedge, node.depth)
-            r <- 1/r
+        if (type != "unrooted") { # for "fan" and "radial" trees (open.angle)
+            ## if the tips are not in the same order in tip.label
+            ## and in edge[, 2], we must reorder the angles: we
+            ## use `xx' to store temporarily the angles
+            TIPS <- x$edge[which(x$edge[, 2] <= Ntip), 2]
+            xx <- seq(0, twopi * (1 - 1/Ntip) - twopi * open.angle/360,
+                      length.out = Ntip)
+            theta <- double(Ntip)
+            theta[TIPS] <- xx
+            theta <- c(theta, numeric(Nnode))
         }
-        theta <- theta + rotate.tree
-        if (root.edge) r <- r + x$root.edge
-        xx <- r * cos(theta)
-        yy <- r * sin(theta)
-    }, "unrooted" = {
-        nb.sp <- .nodeDepth(Ntip, Nnode, z$edge, Nedge, node.depth)
-        XY <- if (use.edge.length)
-            unrooted.xy(Ntip, Nnode, z$edge, z$edge.length, nb.sp, rotate.tree)
-        else
-            unrooted.xy(Ntip, Nnode, z$edge, rep(1, Nedge), nb.sp, rotate.tree)
-        ## rescale so that we have only positive values
-        xx <- XY$M[, 1] - min(XY$M[, 1])
-        yy <- XY$M[, 2] - min(XY$M[, 2])
-    }, "radial" = {
-        r <- .nodeDepth(Ntip, Nnode, z$edge, Nedge, node.depth)
-        r[r == 1] <- 0
-        r <- 1 - r/Ntip
-        theta <- .nodeHeight(z$edge, Nedge, theta) + rotate.tree
-        xx <- r * cos(theta)
-        yy <- r * sin(theta)
-    })
-}
+
+        switch(type, "fan" = {
+            theta <- .nodeHeight(z$edge, Nedge, theta)
+            if (use.edge.length) {
+                r <- .nodeDepthEdgelength(Ntip, Nnode, z$edge, Nedge, z$edge.length)
+            } else {
+                r <- .nodeDepth(Ntip, Nnode, z$edge, Nedge, node.depth)
+                r <- 1/r
+            }
+            theta <- theta + rotate.tree
+            if (root.edge) r <- r + x$root.edge
+            xx <- r * cos(theta)
+            yy <- r * sin(theta)
+        }, "unrooted" = {
+            nb.sp <- .nodeDepth(Ntip, Nnode, z$edge, Nedge, node.depth)
+            XY <- if (use.edge.length)
+                unrooted.xy(Ntip, Nnode, z$edge, z$edge.length, nb.sp, rotate.tree)
+            else
+                unrooted.xy(Ntip, Nnode, z$edge, rep(1, Nedge), nb.sp, rotate.tree)
+            ## rescale so that we have only positive values
+            xx <- XY$M[, 1] - min(XY$M[, 1])
+            yy <- XY$M[, 2] - min(XY$M[, 2])
+        }, "radial" = {
+            r <- .nodeDepth(Ntip, Nnode, z$edge, Nedge, node.depth)
+            r[r == 1] <- 0
+            r <- 1 - r/Ntip
+            theta <- .nodeHeight(z$edge, Nedge, theta) + rotate.tree
+            xx <- r * cos(theta)
+            yy <- r * sin(theta)
+        })
+    }
 
     if (phyloORclado) {
         if (!horizontal) {
@@ -310,172 +310,172 @@ if (phyloORclado) {
     plot.default(0, type = "n", xlim = x.lim, ylim = y.lim, xlab = "",
                  ylab = "", axes = FALSE, asp = asp, ...)
 
-if (plot) {
-    if (is.null(adj))
-        adj <- if (phyloORclado && direction == "leftwards") 1 else 0
-    if (phyloORclado && show.tip.label) {
-        MAXSTRING <- max(strwidth(x$tip.label, cex = cex))
-        loy <- 0
-        if (direction == "rightwards") {
-            lox <- label.offset + MAXSTRING * 1.05 * adj
-        }
-        if (direction == "leftwards") {
-            lox <- -label.offset - MAXSTRING * 1.05 * (1 - adj)
-            ##xx <- xx + MAXSTRING
-        }
-        if (!horizontal) {
-            psr <- par("usr")
-            MAXSTRING <- MAXSTRING * 1.09 * (psr[4] - psr[3])/(psr[2] - psr[1])
-            loy <- label.offset + MAXSTRING * 1.05 * adj
-            lox <- 0
-            srt <- 90 + srt
-            if (direction == "downwards") {
-                loy <- -loy
-                ##yy <- yy + MAXSTRING
-                srt <- 180 + srt
+    if (plot) {
+        if (is.null(adj))
+            adj <- if (phyloORclado && direction == "leftwards") 1 else 0
+        if (phyloORclado && show.tip.label) {
+            MAXSTRING <- max(strwidth(x$tip.label, cex = cex))
+            loy <- 0
+            if (direction == "rightwards") {
+                lox <- label.offset + MAXSTRING * 1.05 * adj
+            }
+            if (direction == "leftwards") {
+                lox <- -label.offset - MAXSTRING * 1.05 * (1 - adj)
+                ##xx <- xx + MAXSTRING
+            }
+            if (!horizontal) {
+                psr <- par("usr")
+                MAXSTRING <- MAXSTRING * 1.09 * (psr[4] - psr[3])/(psr[2] - psr[1])
+                loy <- label.offset + MAXSTRING * 1.05 * adj
+                lox <- 0
+                srt <- 90 + srt
+                if (direction == "downwards") {
+                    loy <- -loy
+                    ##yy <- yy + MAXSTRING
+                    srt <- 180 + srt
+                }
             }
         }
-    }
-    if (type == "phylogram") {
-        phylogram.plot(x$edge, Ntip, Nnode, xx, yy, horizontal,
-                       edge.color, edge.width, edge.lty,
-                       node.color, node.width, node.lty)
-    } else {
-        if (is.null(edge.color)) {
-            edge.color <- par('fg')
-        }
-        if (is.null(edge.width)) {
-            edge.width <- par('lwd')
-        }
-        if (is.null(edge.lty)) {
-            edge.lty <- par('lty')
-        }
-
-        if (type == "fan") {
-            ereorder <- match(z$edge[, 2], x$edge[, 2])
-            if (length(edge.color) > 1) {
-                edge.color <- rep_len(edge.color, Nedge)
-                edge.color <- edge.color[ereorder]
-            }
-            if (length(edge.width) > 1) {
-                edge.width <- rep_len(edge.width, Nedge)
-                edge.width <- edge.width[ereorder]
-            }
-            if (length(edge.lty) > 1) {
-                edge.lty <- rep_len(edge.lty, Nedge)
-                edge.lty <- edge.lty[ereorder]
-            }
-            circular.plot(z$edge, Ntip, Nnode, xx, yy, theta,
-                          r, edge.color, edge.width, edge.lty)
-        } else
-        cladogram.plot(x$edge, xx, yy, edge.color, edge.width, edge.lty)
-    }
-    if (root.edge) {
-        rootcol <- if (length(edge.color) == 1) edge.color else par("fg")
-        rootw <- if (length(edge.width) == 1) edge.width else par("lwd")
-        rootlty <- if (length(edge.lty) == 1) edge.lty else par("lty")
-        if (type == "fan") {
-            tmp <- polar2rect(x$root.edge, theta[ROOT])
-            segments(0, 0, tmp$x, tmp$y, col = rootcol, lwd = rootw, lty = rootlty)
+        if (type == "phylogram") {
+            phylogram.plot(x$edge, Ntip, Nnode, xx, yy, horizontal,
+                           edge.color, edge.width, edge.lty,
+                           node.color, node.width, node.lty)
         } else {
-            switch(direction,
-                   "rightwards" = segments(0, yy[ROOT], x$root.edge, yy[ROOT],
-                                           col = rootcol, lwd = rootw, lty = rootlty),
-                   "leftwards" = segments(xx[ROOT], yy[ROOT], xx[ROOT] + x$root.edge, yy[ROOT],
-                                          col = rootcol, lwd = rootw, lty = rootlty),
-                   "upwards" = segments(xx[ROOT], 0, xx[ROOT], x$root.edge,
-                                        col = rootcol, lwd = rootw, lty = rootlty),
-                   "downwards" = segments(xx[ROOT], yy[ROOT], xx[ROOT], yy[ROOT] + x$root.edge,
-                                          col = rootcol, lwd = rootw, lty = rootlty))
-        }
-    }
-    if (show.tip.label) {
-        if (is.expression(x$tip.label)) underscore <- TRUE
-        if (!underscore) x$tip.label <- gsub("_", " ", x$tip.label)
+            if (is.null(edge.color)) {
+                edge.color <- par('fg')
+            }
+            if (is.null(edge.width)) {
+                edge.width <- par('lwd')
+            }
+            if (is.null(edge.lty)) {
+                edge.lty <- par('lty')
+            }
 
-        if (phyloORclado) {
-            if (align.tip.label) {
-                xx.tmp <- switch(direction,
-                                 "rightwards" = max(xx[1:Ntip]),
-                                 "leftwards" = min(xx[1:Ntip]),
-                                 "upwards" = xx[1:Ntip],
-                                 "downwards" = xx[1:Ntip])
-                yy.tmp <- switch(direction,
-                                 "rightwards" = yy[1:Ntip],
-                                 "leftwards" = yy[1:Ntip],
-                                 "upwards" = max(yy[1:Ntip]),
-                                 "downwards" = min(yy[1:Ntip]))
-                segments(xx[1:Ntip], yy[1:Ntip], xx.tmp, yy.tmp, lty = align.tip.label.lty)
+            if (type == "fan") {
+                ereorder <- match(z$edge[, 2], x$edge[, 2])
+                if (length(edge.color) > 1) {
+                    edge.color <- rep_len(edge.color, Nedge)
+                    edge.color <- edge.color[ereorder]
+                }
+                if (length(edge.width) > 1) {
+                    edge.width <- rep_len(edge.width, Nedge)
+                    edge.width <- edge.width[ereorder]
+                }
+                if (length(edge.lty) > 1) {
+                    edge.lty <- rep_len(edge.lty, Nedge)
+                    edge.lty <- edge.lty[ereorder]
+                }
+                circular.plot(z$edge, Ntip, Nnode, xx, yy, theta,
+                              r, edge.color, edge.width, edge.lty)
+            } else
+            cladogram.plot(x$edge, xx, yy, edge.color, edge.width, edge.lty)
+        }
+        if (root.edge) {
+            rootcol <- if (length(edge.color) == 1) edge.color else par("fg")
+            rootw <- if (length(edge.width) == 1) edge.width else par("lwd")
+            rootlty <- if (length(edge.lty) == 1) edge.lty else par("lty")
+            if (type == "fan") {
+                tmp <- polar2rect(x$root.edge, theta[ROOT])
+                segments(0, 0, tmp$x, tmp$y, col = rootcol, lwd = rootw, lty = rootlty)
             } else {
-                xx.tmp <- xx[1:Ntip]
-                yy.tmp <- yy[1:Ntip]
-            }
-            text(xx.tmp + lox, yy.tmp + loy, x$tip.label, adj = adj,
-                 font = font, srt = srt, cex = cex, col = tip.color)
-        } else {
-            angle <- if (type == "unrooted") XY$axe else atan2(yy[1:Ntip], xx[1:Ntip]) # in radians
-
-            lab4ut <-
-                if (is.null(lab4ut)) {
-                    if (type == "unrooted") "horizontal" else "axial"
-                } else match.arg(lab4ut, c("horizontal", "axial"))
-
-            xx.tips <- xx[1:Ntip]
-            yy.tips <- yy[1:Ntip]
-            if (label.offset) {
-                xx.tips <- xx.tips + label.offset * cos(angle)
-                yy.tips <- yy.tips + label.offset * sin(angle)
-            }
-
-            if (lab4ut == "horizontal") {
-                y.adj <- x.adj <- numeric(Ntip)
-                sel <- abs(angle) > 0.75 * pi
-                x.adj[sel] <- -strwidth(x$tip.label)[sel] * 1.05
-                sel <- abs(angle) > pi/4 & abs(angle) < 0.75 * pi
-                x.adj[sel] <- -strwidth(x$tip.label)[sel] * (2 * abs(angle)[sel] / pi - 0.5)
-                sel <- angle > pi / 4 & angle < 0.75 * pi
-                y.adj[sel] <- strheight(x$tip.label)[sel] / 2
-                sel <- angle < -pi / 4 & angle > -0.75 * pi
-                y.adj[sel] <- -strheight(x$tip.label)[sel] * 0.75
-                text(xx.tips + x.adj * cex, yy.tips + y.adj * cex,
-                     x$tip.label, adj = c(adj, 0), font = font,
-                     srt = srt, cex = cex, col = tip.color)
-            } else { # if lab4ut == "axial"
-                if (align.tip.label) {
-                    POL <- rect2polar(xx.tips, yy.tips)
-                    POL$r[] <- max(POL$r)
-                    REC <- polar2rect(POL$r, POL$angle)
-                    xx.tips <- REC$x
-                    yy.tips <- REC$y
-                    segments(xx[1:Ntip], yy[1:Ntip], xx.tips, yy.tips, lty = align.tip.label.lty)
-                }
-                if (type == "unrooted") {
-                    adj <- abs(angle) > pi/2
-                    angle <- angle * 180/pi # switch to degrees
-                    angle[adj] <- angle[adj] - 180
-                    adj <- as.numeric(adj)
-                } else {
-                    s <- xx.tips < 0
-                    angle <- angle * 180/pi
-                    angle[s] <- angle[s] + 180
-                    adj <- as.numeric(s)
-                }
-                ## `srt' takes only a single value, so can't vectorize this:
-                ## (and need to 'elongate' these vectors:)
-                font <- rep(font, length.out = Ntip)
-                tip.color <- rep(tip.color, length.out = Ntip)
-                cex <- rep(cex, length.out = Ntip)
-                for (i in 1:Ntip)
-                    text(xx.tips[i], yy.tips[i], x$tip.label[i], font = font[i],
-                         cex = cex[i], srt = angle[i], adj = adj[i],
-                         col = tip.color[i])
+                switch(direction,
+                       "rightwards" = segments(0, yy[ROOT], x$root.edge, yy[ROOT],
+                                               col = rootcol, lwd = rootw, lty = rootlty),
+                       "leftwards" = segments(xx[ROOT], yy[ROOT], xx[ROOT] + x$root.edge, yy[ROOT],
+                                              col = rootcol, lwd = rootw, lty = rootlty),
+                       "upwards" = segments(xx[ROOT], 0, xx[ROOT], x$root.edge,
+                                            col = rootcol, lwd = rootw, lty = rootlty),
+                       "downwards" = segments(xx[ROOT], yy[ROOT], xx[ROOT], yy[ROOT] + x$root.edge,
+                                              col = rootcol, lwd = rootw, lty = rootlty))
             }
         }
+        if (show.tip.label) {
+            if (is.expression(x$tip.label)) underscore <- TRUE
+            if (!underscore) x$tip.label <- gsub("_", " ", x$tip.label)
+
+            if (phyloORclado) {
+                if (align.tip.label) {
+                    xx.tmp <- switch(direction,
+                                     "rightwards" = max(xx[1:Ntip]),
+                                     "leftwards" = min(xx[1:Ntip]),
+                                     "upwards" = xx[1:Ntip],
+                                     "downwards" = xx[1:Ntip])
+                    yy.tmp <- switch(direction,
+                                     "rightwards" = yy[1:Ntip],
+                                     "leftwards" = yy[1:Ntip],
+                                     "upwards" = max(yy[1:Ntip]),
+                                     "downwards" = min(yy[1:Ntip]))
+                    segments(xx[1:Ntip], yy[1:Ntip], xx.tmp, yy.tmp, lty = align.tip.label.lty)
+                } else {
+                    xx.tmp <- xx[1:Ntip]
+                    yy.tmp <- yy[1:Ntip]
+                }
+                text(xx.tmp + lox, yy.tmp + loy, x$tip.label, adj = adj,
+                     font = font, srt = srt, cex = cex, col = tip.color)
+            } else {
+                angle <- if (type == "unrooted") XY$axe else atan2(yy[1:Ntip], xx[1:Ntip]) # in radians
+
+                lab4ut <-
+                    if (is.null(lab4ut)) {
+                        if (type == "unrooted") "horizontal" else "axial"
+                    } else match.arg(lab4ut, c("horizontal", "axial"))
+
+                xx.tips <- xx[1:Ntip]
+                yy.tips <- yy[1:Ntip]
+                if (label.offset) {
+                    xx.tips <- xx.tips + label.offset * cos(angle)
+                    yy.tips <- yy.tips + label.offset * sin(angle)
+                }
+
+                if (lab4ut == "horizontal") {
+                    y.adj <- x.adj <- numeric(Ntip)
+                    sel <- abs(angle) > 0.75 * pi
+                    x.adj[sel] <- -strwidth(x$tip.label)[sel] * 1.05
+                    sel <- abs(angle) > pi/4 & abs(angle) < 0.75 * pi
+                    x.adj[sel] <- -strwidth(x$tip.label)[sel] * (2 * abs(angle)[sel] / pi - 0.5)
+                    sel <- angle > pi / 4 & angle < 0.75 * pi
+                    y.adj[sel] <- strheight(x$tip.label)[sel] / 2
+                    sel <- angle < -pi / 4 & angle > -0.75 * pi
+                    y.adj[sel] <- -strheight(x$tip.label)[sel] * 0.75
+                    text(xx.tips + x.adj * cex, yy.tips + y.adj * cex,
+                         x$tip.label, adj = c(adj, 0), font = font,
+                         srt = srt, cex = cex, col = tip.color)
+                } else { # if lab4ut == "axial"
+                    if (align.tip.label) {
+                        POL <- rect2polar(xx.tips, yy.tips)
+                        POL$r[] <- max(POL$r)
+                        REC <- polar2rect(POL$r, POL$angle)
+                        xx.tips <- REC$x
+                        yy.tips <- REC$y
+                        segments(xx[1:Ntip], yy[1:Ntip], xx.tips, yy.tips, lty = align.tip.label.lty)
+                    }
+                    if (type == "unrooted") {
+                        adj <- abs(angle) > pi/2
+                        angle <- angle * 180/pi # switch to degrees
+                        angle[adj] <- angle[adj] - 180
+                        adj <- as.numeric(adj)
+                    } else {
+                        s <- xx.tips < 0
+                        angle <- angle * 180/pi
+                        angle[s] <- angle[s] + 180
+                        adj <- as.numeric(s)
+                    }
+                    ## `srt' takes only a single value, so can't vectorize this:
+                    ## (and need to 'elongate' these vectors:)
+                    font <- rep(font, length.out = Ntip)
+                    tip.color <- rep(tip.color, length.out = Ntip)
+                    cex <- rep(cex, length.out = Ntip)
+                    for (i in 1:Ntip)
+                        text(xx.tips[i], yy.tips[i], x$tip.label[i], font = font[i],
+                             cex = cex[i], srt = angle[i], adj = adj[i],
+                             col = tip.color[i])
+                }
+            }
+        }
+        if (show.node.label)
+            text(xx[ROOT:length(xx)] + label.offset, yy[ROOT:length(yy)],
+                 x$node.label, adj = adj, font = font, srt = srt, cex = cex)
     }
-    if (show.node.label)
-        text(xx[ROOT:length(xx)] + label.offset, yy[ROOT:length(yy)],
-             x$node.label, adj = adj, font = font, srt = srt, cex = cex)
-}
     L <- list(type = type, use.edge.length = use.edge.length,
               node.pos = node.pos, node.depth = node.depth,
               show.tip.label = show.tip.label,

--- a/R/plot.phylo.R
+++ b/R/plot.phylo.R
@@ -522,7 +522,9 @@ phylogram.plot <- function(edge, Ntip, Nnode, xx, yy, horizontal,
 
     # Node and edge styling
 
-    .one.style <- function (style) list(h = style, v = style)
+    .one.style <- function (style) {
+        list(h = rep_len(style, Nedge), v = rep_len(style, Ntip + Nnode))
+    }
 
     .edge.style <- function (edge.style, node.style) {
         # node.style is fixed
@@ -591,6 +593,10 @@ phylogram.plot <- function(edge, Ntip, Nnode, xx, yy, horizontal,
     color.v <- colors$v
     width.v <- widths$v
     lty.v <- ltys$v
+    edge.color <- colors$h
+    edge.width <- widths$h
+    edge.lth <- ltys$h
+
     for (i in seq_len(Nnode)) {
         br <- edgeChildren[[i]]
         if (length(br) == 1) {
@@ -632,14 +638,14 @@ phylogram.plot <- function(edge, Ntip, Nnode, xx, yy, horizontal,
     if (horizontal) {
         # draw horizontal lines
         segments(x0h, y0h, x1h, y0h,
-                 col = colors$h, lwd = widths$h, lty = ltys$h)
+                 col = edge.color, lwd = edge.width, lty = edge.lty)
         # draw vertical lines
         segments(x0v, y0v, x0v, y1v,
                  col = color.v, lwd = width.v, lty = lty.v)
     } else {
         # draws vertical lines
         segments(y0h, x0h, y0h, x1h,
-                 col = colors$h, lwd = widths$h, lty = ltys$h)
+                 col = edge.color, lwd = edge.width, lty = edge.lty)
         # draws horizontal lines
         segments(y0v, x0v, y1v, x0v,
                  col = color.v, lwd = width.v, lty = lty.v)


### PR DESCRIPTION
There are a number of settings where it is useful to be able to style the vertical lines associated with polytomies ([example](https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0212942)).
I'm hoping that it would be possible to extend the functionality of `plot.phylo()` to support this.

This PR adds `node.color`, `node.width` and `node.lty` parameters that allow nodes to be styled separately from their pendant edges.  If these parameters are unspecified, the existing behaviour of `plot.phylo()` remains unchanged.

If `node.color` (etc.) parameters are specified and `edge.color` is unspecified, then edge colours will be inferred based on the child node.

Example output:
```r
library('TreeTools') # For CollapseNode, BalancedTree
plot(CollapseNode(BalancedTree(10), 18),
     edge.color = viridisLite::plasma(18),
     node.color = c(rep('blue', 10), rev(viridisLite::inferno(9))),
     node.lty = c(rep('solid', 15), rep('dotted', 1), rep('dashed', 2)),
     edge.lty = 'solid',
     node.width = c(rep(1, 10), 1:8),
     edge.width = (1:17) / 2
     )
```
![image](https://user-images.githubusercontent.com/1695515/121168517-f5afb400-c84a-11eb-8e06-8b824625427d.png)

```r
plot(CollapseNode(BalancedTree(10), 18),
     direction = 'upwards',
     node.color = c(rep('red', 10), rep('grey', 4), rep('red', 2), 'green', 'red'))
```
![image](https://user-images.githubusercontent.com/1695515/121169404-e11feb80-c84b-11eb-9aed-5824e7387828.png)


I've checked a few basic test cases – but is there a standard set of test plots that I should verify reproduced correctly with the new code?

I have not attempted to extended this functionality to plotting types other than "phylogram".