### PR TITLE
Improve prop.part and consensus

### DIFF
--- a/R/dist.topo.R
+++ b/R/dist.topo.R
@@ -380,7 +380,7 @@ SHORTwise <- function(x) {
     x
 }
 
-consensus <- function(..., p = 1, check.labels = TRUE)
+consensus <- function(..., p = 1, check.labels = TRUE, rooted = FALSE)
 {
     foo <- function(ic, node) {
         ## ic: index of 'pp'
@@ -411,19 +411,24 @@ consensus <- function(..., p = 1, check.labels = TRUE)
 
     if (!is.null(attr(obj, "TipLabel")))
         labels <- attr(obj, "TipLabel")
-    else {
+    else { 
         labels <- obj[[1]]$tip.label
         if (check.labels) obj <- .compressTipLabel(obj)
     }
+    if(!rooted) obj <- root(obj, 1)
+    
     ntree <- length(obj)
     ## Get all observed partitions and their frequencies:
     pp <- prop.part(obj, check.labels = FALSE)
     ## Drop the partitions whose frequency is less than 'p':
     if (p == 0.5) p <- 0.5000001 # avoid incompatible splits
-    pp <- pp[attr(pp, "number") >= p * ntree]
+    bs <- attr(pp, "number")
+    pp <- pp[bs >= p * ntree] 
+    bs <- bs[bs >= p * ntree]
     ## Get the order of the remaining partitions by decreasing size:
     ind <- order(lengths(pp), decreasing = TRUE)
     pp <- pp[ind]
+    bs <- bs[ind]
     n <- length(labels)
     m <- length(pp)
     edge <- matrix(0L, n + m - 1, 2)
@@ -435,6 +440,6 @@ consensus <- function(..., p = 1, check.labels = TRUE)
         pos <- 1L
         foo(1, nextnode)
     }
-    structure(list(edge = edge, tip.label = labels,
+    structure(list(edge = edge, tip.label = labels, node.label = bs/ntree,
               Nnode = m), class = "phylo")
 }

--- a/man/consensus.Rd
+++ b/man/consensus.Rd
@@ -2,7 +2,7 @@
 \alias{consensus}
 \title{Concensus Trees}
 \usage{
-consensus(..., p = 1, check.labels = TRUE)
+consensus(..., p = 1, check.labels = TRUE, rooted = FALSE)
 }
 \arguments{
   \item{\dots}{either (i) a single object of class \code{"phylo"}, (ii) a
@@ -14,6 +14,8 @@ consensus(..., p = 1, check.labels = TRUE)
     of each tree. If \code{FALSE} (the default), it is assumed that all
     trees have the same tip labels, and that they are in the same order
     (see details).}
+  \item{rooted}{a logical specifying whether the trees should be treated as 
+    rooted or not.}  
 }
 \description{
   Given a series of trees, this function returns the consensus tree. By

--- a/man/plot.phylo.Rd
+++ b/man/plot.phylo.Rd
@@ -14,7 +14,7 @@
     adj = NULL, srt = 0, no.margin = FALSE,
     root.edge = FALSE, label.offset = 0, underscore = FALSE,
     x.lim = NULL, y.lim = NULL, direction = "rightwards",
-    lab4ut = NULL, tip.color = "black", plot = TRUE,
+    lab4ut = NULL, tip.color = par("col"), plot = TRUE,
     rotate.tree = 0, open.angle = 0, node.depth = 1,
     align.tip.label = FALSE, ...)
 \method{plot}{multiPhylo}(x, layout = 1, ...)

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -5,6 +5,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // bipartition2
 std::vector< std::vector<int> > bipartition2(IntegerMatrix orig, int nTips);
 RcppExport SEXP _ape_bipartition2(SEXP origSEXP, SEXP nTipsSEXP) {

--- a/src/prop_part.cpp
+++ b/src/prop_part.cpp
@@ -31,17 +31,6 @@ std::vector< std::vector<int> > bipartition2(IntegerMatrix orig, int nTips) {
     return out;
 }
 
-// call-by-reference is important here
-int SameClade(const std::vector<int>& clade1, const std::vector<int>& clade2)
-{
-    unsigned int n = clade1.size();
-    if (n != clade2.size()) return 0;
-//    c1 = INTEGER(clade1);
-//    c2 = INTEGER(clade2);
-    for (unsigned int i = 0; i < n; i++)
-        if (clade1[i] != clade2[i]) return 0;
-    return 1;
-}
 
 // [[Rcpp::export]]
 List prop_part2(SEXP trees, int nTips){
@@ -57,11 +46,10 @@ List prop_part2(SEXP trees, int nTips){
         List tmpTree = tr(k);
         IntegerMatrix tmpE = tmpTree["edge"];
         std::vector< std::vector<int> > bp = bipartition2(tmpE, nTips);
-
         for (unsigned int i = 1; i < bp.size(); i++) {
             unsigned int j = 1;
             next_j:
-                if (SameClade(bp[i], ans[j])) {
+                if (bp[i] == ans[j]) {
                     no[j]++;
                     continue;
                 }
@@ -76,7 +64,5 @@ List prop_part2(SEXP trees, int nTips){
     List output = wrap(ans);
     output.attr("number") = no;
     output.attr("class") = "prop.part";
-//    return Rcpp::List::create(Rcpp::Named("splits") = ans,
-//                              Rcpp::Named("number") = no);
     return output;
 }


### PR DESCRIPTION
Hi Emmanuel, 
see commit messages. Small improvements to `prop.part` and some changes to `consensus`. 
`consensus` used to show support for clades, change will allow support for clades or bipartitions.
Added support values as node labels.
Updated man pages.  
Cheers, 
Klaus 