### PR TITLE
fix issue of read.nexus to solve the labels of translation contains space

### DIFF
--- a/R/read.nexus.R
+++ b/R/read.nexus.R
@@ -204,7 +204,19 @@ read.nexus <- function(file, tree.names = NULL, force.multi = FALSE)
     if (translation) {
         end <- semico[semico > i2][1]
         x <- X[(i2 + 1):end] # assumes there's a 'new line' after "TRANSLATE"
-        x <- unlist(strsplit(x, "[,; \t]"))
+        #x <- unlist(strsplit(x, "[,; \t]"))
+        ################################################
+        # when the label of translation contains space #
+        # 1 "tip 1 a",                                 #
+        # 2 "tip 2"                                    #
+        ################################################
+        # remove the space and tab before the string
+        x <- gsub("^\\s+", "", x)
+        # remove the , ; symbol
+        x <- gsub("[,;]", "", x)
+        # split with the first space 
+        x <- unlist(regmatches(x, regexpr("\\s", x), invert=TRUE))
+        ###############################################
         x <- x[nzchar(x)]
         TRANS <- matrix(x, ncol = 2, byrow = TRUE)
         TRANS[, 2] <- gsub("['\"]", "", TRANS[, 2])

--- a/R/read.nexus.R
+++ b/R/read.nexus.R
@@ -215,7 +215,7 @@ read.nexus <- function(file, tree.names = NULL, force.multi = FALSE)
         # remove the , ; symbol
         x <- gsub("[,;]", "", x)
         # split with the first space 
-        x <- unlist(regmatches(x, regexpr("\\s", x), invert=TRUE))
+        x <- unlist(regmatches(x, regexpr("\\s+", x), invert=TRUE))
         ###############################################
         x <- x[nzchar(x)]
         TRANS <- matrix(x, ncol = 2, byrow = TRUE)


### PR DESCRIPTION
If the labels in Translation contain space, the original `read.nexus` will generate an error.

The related [issue](https://github.com/YuLab-SMU/treeio/issues/47)

```
> library(magrittr)
> readLines("./problem.tree.txt") %>% writeLines()
#NEXUS

Begin trees;
        Translate
                   1 "Tip 1",
                   2 "Tip 2",
                   3 "Tip 3 c"
;
tree TREE1 = ((1[&height=0.3]:1,2[&height=0.3]:1)[&height=0.3]:1,3[&height=0.3])[&height=0.3]:1;
End;
```

This issue was fixed following the steps.

First, the space and tab before the string was removed
Second, The `,` and `;` symbols were also removed
Last, split the label string with the first space (start from left)

```
> library(ape)
> read.nexus("./problem.tree.txt")

Phylogenetic tree with 3 tips and 2 internal nodes.

Tip labels:
  Tip 1, Tip 2, Tip 3 c

Rooted; includes branch lengths.
```

