### PR TITLE
Support lists of trees in `write.tree()`

### DIFF
--- a/R/write.tree.R
+++ b/R/write.tree.R
@@ -27,8 +27,9 @@ checkLabel <- function(x)
 write.tree <-
     function(phy, file = "", append = FALSE, digits = 10, tree.names = FALSE)
 {
-    if (!(inherits(phy, c("phylo", "multiPhylo"))))
-        stop("object \"phy\" has no trees")
+    if (!(inherits(phy, c("phylo", "multiPhylo"))) &&
+        !all(vapply(phy, inherits, logical(1), 'phylo')))
+        stop("object \"phy\" must contain trees")
 
     if (inherits(phy, "phylo")) phy <- c(phy)
     N <- length(phy)

--- a/tests/testthat/test-write-tree.R
+++ b/tests/testthat/test-write-tree.R
@@ -1,0 +1,8 @@
+test_that("write.tree() writes lists", {
+  trees <- c('((a,b),(c,d));', '(a,(b,d,c));')
+  phy <- read.tree(text = trees)
+
+  expect_equal(write.tree(phy), trees)
+  expect_equal(write.tree(unclass(phy)), trees)
+  expect_error(write.tree(c('not-a-tree', unclass(phy))))
+})


### PR DESCRIPTION
I often work with lists of phylo objects, so would find it useful if `write.tree()` could handle such lists without my having to add the class "multiPhylo".  This PR should accomplish this.