### PR TITLE
fix the order of tip in as.hclust.phylo

### DIFF
--- a/R/as.phylo.R
+++ b/R/as.phylo.R
@@ -97,6 +97,8 @@ as.hclust.phylo <- function(x, ...)
     if (!is.rooted(x)) stop("the tree is not rooted")
     n <- length(x$tip.label)
     if (n == 1) stop("needs n >= 2 observations for a classification")
+    is_tip <- x$edge[,2] <= n
+    order <- x$edge[is_tip, 2]
     if (n == 2) {
         m <- matrix(c(-1L, -2L), 1, 2)
         bt <- x$edge.length[1]
@@ -121,7 +123,7 @@ as.hclust.phylo <- function(x, ...)
         m[match(oldnodes, m)] <- 1:(N - 1)
         names(bt) <- NULL
     }
-    obj <- list(merge = m, height = 2*bt, order = 1:n, labels = x$tip.label,
+    obj <- list(merge = m, height = 2*bt, order = order, labels = x$tip.label,
                 call = match.call(), method = "unknown")
     class(obj) <- "hclust"
     obj

--- a/man/drop.tip.Rd
+++ b/man/drop.tip.Rd
@@ -63,7 +63,7 @@ extract.clade(phy, node, root.edge = 0, collapse.singles = TRUE,
   Note that \code{subtree = TRUE} implies \code{trim.internal = TRUE}.
 
   To undestand how the option \code{root.edge} works, see the examples
-  below. If \item{rooted = FALSE} and the tree has a root edge, the
+  below. If \code{rooted = FALSE} and the tree has a root edge, the
   latter is removed in the output.
 }
 \value{an object of class \code{"phylo"}.}


### PR DESCRIPTION
The order of tip in original `as.hclust.phylo` might be incorrect.

## Original 
```
> library(ape)
> set.seed(123)
> dd <- matrix(abs(rnorm(100)), 10)
> xx <- hclust(as.dist(dd))
> tr <- as.phylo(xx)
> yy <- as.hclust(tr)
> library(ggplotify)
> library(patchwork)
> as.ggplot(~plot(xx)) + as.ggplot(~plot(tr)) + as.ggplot(~plot(yy))
```
![xx](https://user-images.githubusercontent.com/17870644/135373181-b215f492-1ef4-41f9-bfe7-c00ab6c443d6.PNG)

## This request

```
> library(ape)
> set.seed(123)
> dd <- matrix(abs(rnorm(100)), 10)
> xx <- hclust(as.dist(dd))
> tr <- as.phylo(xx)
> yy <- as.hclust(tr)
> library(ggplotify)
> library(patchwork)
> as.ggplot(~plot(xx)) + as.ggplot(~plot(tr)) + as.ggplot(~plot(yy))
```
![xx1](https://user-images.githubusercontent.com/17870644/135373236-ccdc1f57-7818-4032-ae39-7cdd4191955b.PNG)
