### PR TITLE
Support n < 2 in `unique.multiPhylo()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,7 @@ ZipData: no
 Description: Functions for reading, writing, plotting, and manipulating phylogenetic trees, analyses of comparative data in a phylogenetic framework, ancestral character analyses, analyses of diversification and macroevolution, computing distances from DNA sequences, reading and writing nucleotide sequences as well as importing from BioConductor, and several tools such as Mantel's test, generalized skyline plots, graphical exploration of phylogenetic data (alex, trex, kronoviz), estimation of absolute evolutionary rates and clock-like trees using mean path lengths and penalized likelihood, dating trees with non-contemporaneous sequences, translating DNA into AA sequences, and assessing sequence alignments. Phylogeny estimation can be done with the NJ, BIONJ, ME, MVR, SDM, and triangle methods, and several methods handling incomplete distance matrices (NJ*, BIONJ*, MVR*, and the corresponding triangle method). Some functions call external applications (PhyML, Clustal, T-Coffee, Muscle) whose results are returned into R.
 License: GPL-2 | GPL-3
 URL: http://ape-package.ird.fr/
-Encoding: UTF-8 
+Encoding: UTF-8
 Config/Needs/check: rcmdcheck
 Config/Needs/memcheck: devtools, rcmdcheck
 Config/testthat/edition: 3

--- a/R/unique.multiPhylo.R
+++ b/R/unique.multiPhylo.R
@@ -13,6 +13,11 @@ unique.multiPhylo <-
              use.tip.label = TRUE, ...)
 {
     n <- length(x)
+    if (n == 0L) {
+        return(x)
+    } else if (n == 1L) {
+        return(structure(x, old.index = 1L))
+    }
     keep <- 1L
     old.index <- seq_len(n)
     for (i in 2:n) {

--- a/tests/testthat/test-unique-multiPhylo.R
+++ b/tests/testthat/test-unique-multiPhylo.R
@@ -1,0 +1,6 @@
+test_that("unique.multiPhylo()", {
+  tree <- read.tree(text = '(a, b);')
+  expect_equal(unique(c(tree, tree)), structure(c(tree), old.index = rep(1L, 2)))
+  expect_equal(unique(c(tree)), structure(c(tree), old.index = rep(1L, 1)))
+  expect_equal(unique(c(tree)[-1]), structure(c(tree)[-1]))
+})


### PR DESCRIPTION
Fixes incorrect behaviour in the case where `length(x.multiPhylo) < 1`
```r
tree <- read.tree(text = '(a, b);')
c(tree, tree) # = tree
unique(c(tree) # = tree
unique(c(tree)[-1]) # = length zero multiPhylo object
```