### PR TITLE
improve comparePhylo

### DIFF
--- a/R/comparePhylo.R
+++ b/R/comparePhylo.R
@@ -8,7 +8,7 @@
 ## See the file ../COPYING for licensing issues.
 
 comparePhylo <- function(x, y, plot = FALSE, force.rooted = FALSE,
-                         use.edge.length = FALSE)
+                         use.edge.length = FALSE, location="bottomleft", ...)
 {
     tree1 <- deparse(substitute(x))
     tree2 <- deparse(substitute(y))
@@ -76,18 +76,18 @@ comparePhylo <- function(x, y, plot = FALSE, force.rooted = FALSE,
         }
         if (plot) {
             layout(matrix(1:2, 1, 2))
-            plot(x, use.edge.length = use.edge.length, main = tree1)
+            plot(x, use.edge.length = use.edge.length, main = tree1, ...)
             nodelabels(node = which(tmp) + n1, pch = 19, col = "blue", cex = 2)
-            legend("topleft", legend = paste("Clade absent in", tree2), pch = 19, col = "blue")
+            legend(location, legend = paste("Clade absent in", tree2), pch = 19, col = "blue")
         }
         if (any(tmp <- is.na(mk21))) {
             nk <- sum(tmp)
             msg <- c(msg, paste(nk, if (nk == 1) "clade" else "clades", "in", tree2, "not in", tree1))
         }
         if (plot) {
-            plot(y, use.edge.length = use.edge.length, main = tree2)
+            plot(y, use.edge.length = use.edge.length, main = tree2, ...)
             nodelabels(node = which(tmp) + n2, pch = 19, col = "red", cex = 2)
-            legend("topleft", legend = paste("Clade absent in", tree1), pch = 19, col = "red")
+            legend(location, legend = paste("Clade absent in", tree1), pch = 19, col = "red")
         }
         nodes1 <- which(!is.na(mk12))
         nodes2 <- mk12[!is.na(mk12)]
@@ -152,11 +152,11 @@ comparePhylo <- function(x, y, plot = FALSE, force.rooted = FALSE,
                 }
             }
             plot(TR[[1]], "u", use.edge.length = use.edge.length,
-                 edge.color = edgecol1, edge.width = edgew1, main = tree1, cex = 1.3, font =1)
-            legend("bottomright", legend = "Split present in both trees",
+                 edge.color = edgecol1, edge.width = edgew1, main = tree1, cex = 1.3, font =1, ...)
+            legend(location, legend = "Split present in both trees",
                    lty = 1, col = "black", lwd = 5)
             plot(TR[[2]], "u", use.edge.length = use.edge.length,
-                 edge.color = edgecol2, edge.width = edgew2, main = tree2, cex = 1.3, font =1)
+                 edge.color = edgecol2, edge.width = edgew2, main = tree2, cex = 1.3, font =1, ...)
         }
     }
     res$messages <- paste0(msg, ".")

--- a/man/comparePhylo.Rd
+++ b/man/comparePhylo.Rd
@@ -8,7 +8,7 @@
 }
 \usage{
 comparePhylo(x, y, plot = FALSE, force.rooted = FALSE,
-             use.edge.length = FALSE)
+             use.edge.length = FALSE, ...)
 \method{print}{comparePhylo}(x, ...)
 }
 \arguments{
@@ -19,7 +19,9 @@ comparePhylo(x, y, plot = FALSE, force.rooted = FALSE,
     considered rooted even if \code{is.rooted} returns \code{FALSE}.}
   \item{use.edge.length}{a logical value passed to
     \code{\link{plot.phylo}} (see below).}
-  \item{\dots}{unused.}
+  \item{location}{location of where to position the \code{\link{legend}}.}  
+  \item{\dots}{further parameters used by \code{\link{plot.phylo}}, in function
+  \code{print.comparePhylo} unused.}
 }
 \details{
   In all cases, the numbers of tips and of nodes and the tip labels are


### PR DESCRIPTION
Hello Emmanuel, 
I am teaching a bioinformatics class and used `comparePhylo()`. 
I added a `...` argument to allow for additionally plot arguments. E.g. `lab4ut="axial"` is often nicer for unrooted trees. 
Additionally I added an argument location to move the legend around as it sometimes covers important parts of the plot. 
Cheers, 
Klaus 