### PR TITLE
Allow different "order" in unroot

### DIFF
--- a/R/root.R
+++ b/R/root.R
@@ -52,7 +52,7 @@ unroot <- function(phy) UseMethod("unroot")
     ophy <- attr(phy, "order")
     if(is.null(ophy) || !(ophy %in% c("cladewise", "postorder", 
                                       "pruningwise"))){
-        phy <- reorder(phy)
+        phy <- .reorder_ape(phy, "cladewise", FALSE, as.integer(n), 1L)
         ophy <- attr(phy, "order")
     }    
     if (ophy != "cladewise") {

--- a/R/root.R
+++ b/R/root.R
@@ -50,7 +50,12 @@ unroot <- function(phy) UseMethod("unroot")
 ### situated in phy$edge[N - 2L, 1L] will be the new root...
 
     ophy <- attr(phy, "order")
-    if (!is.null(ophy) && ophy != "cladewise") {
+    if(is.null(ophy) || !(ophy %in% c("cladewise", "postorder", 
+                                      "pruningwise"))){
+        phy <- reorder(phy)
+        ophy <- attr(phy, "order")
+    }    
+    if (ophy != "cladewise") {
         NEWROOT <- phy$edge[N - 2L, 1L]
         EDGEROOT <- c(N, N - 1L)
         ## make sure EDGEROOT is ordered as described above:


### PR DESCRIPTION
Hi @emmanuelparadis, 
this fixes a problem which might happen if the order is not one of "cladewise", "postorder" or "pruningwise". @ms609 package TreeTools might return trees of order "preorder" and this causes a crash with the following code: 
```
library(ape)
tree <- rtree(5)
attr(tree, "order") <- "preorder"
tree <- unroot(tree) 
tree <- reorder("postorder")
```
In fact this happened inside `RF.dist` for example, so I finally tracked it down.
Cheers, 
Klaus  
