### PR TITLE
fix the edge.length or height when converting between the hclust and …

### DIFF
--- a/R/as.phylo.R
+++ b/R/as.phylo.R
@@ -67,7 +67,7 @@ as.phylo.hclust <- function(x, ...)
     }
     if (is.null(x$labels))
         x$labels <- as.character(1:(N + 1))
-    obj <- list(edge = edge, edge.length = edge.length / 2,
+    obj <- list(edge = edge, edge.length = edge.length,
                 tip.label = x$labels, Nnode = N)
     class(obj) <- "phylo"
     reorder(obj)
@@ -123,7 +123,7 @@ as.hclust.phylo <- function(x, ...)
         m[match(oldnodes, m)] <- 1:(N - 1)
         names(bt) <- NULL
     }
-    obj <- list(merge = m, height = 2*bt, order = order, labels = x$tip.label,
+    obj <- list(merge = m, height = bt, order = order, labels = x$tip.label,
                 call = match.call(), method = "unknown")
     class(obj) <- "hclust"
     obj


### PR DESCRIPTION
The edge.length of `as.phylo.hclust` method might be incorrect.

# The original

```
library(ape)
set.seed(123)
dd <- matrix(abs(rnorm(100)), 10)
xx <- hclust(as.dist(dd))
tr <- as.phylo(xx)
plot(xx, hang = -1)
```
![x1](https://user-images.githubusercontent.com/17870644/172115221-f35e5e9d-3b82-4d15-bad3-15edc2a7c74a.PNG)
```
plot(tr)
axisPhylo()
```
![x2](https://user-images.githubusercontent.com/17870644/172115397-db817972-c611-4c1c-915c-a6acca5192d0.PNG)

The `axis` of phylo converted from `hclust` is different with the original `hclust`.

# This request

```
library(ape)
set.seed(123)
dd <- matrix(abs(rnorm(100)), 10)
xx <- hclust(as.dist(dd))
tr <- as.phylo(xx)
plot(tr)
axisPhylo()
```
![x3](https://user-images.githubusercontent.com/17870644/172115975-a9bfd024-7df0-447c-b558-dc4ea0bfa092.PNG)
The `height` of `as.hclust.phylo` also was adjusted according to the `edge.lenght` of `as.phylo.hclust`
```
yy <- as.hclust(tr)
aplot::plot_list(~plot(xx, hang = -1), ~plot(yy, hang = -1))
```
![x4](https://user-images.githubusercontent.com/17870644/172116273-f053f3ef-cc11-49b5-ba19-0eb4fcfebdec.PNG)


