### PR TITLE
Bug fix in .write.tree2

### DIFF
--- a/R/write.tree.R
+++ b/R/write.tree.R
@@ -74,15 +74,15 @@ write.tree <-
     n <- length(phy$tip.label)
 
     ## terminal branches:
-    terms <- phy$edge[, 2] <= n
-    TERMS <- phy$tip.label[phy$edge[terms, 2]]
+    terms <- match(seq_len(n), phy$edge[, 2])
+    TERMS <- phy$tip.label
     if (brl) TERMS <- paste0(TERMS, sprintf(f.d, phy$edge.length[terms]))
 
     ## internal branches, including root edge:
     INTS <- rep(")", phy$Nnode)
     if (nodelab) INTS <- paste0(INTS, phy$node.label)
     if (brl) {
-        tmp <- phy$edge.length[!terms][order(phy$edge[!terms, 2])]
+        tmp <- phy$edge.length[-terms][order(phy$edge[-terms, 2])]
         tmp <- c("", sprintf(f.d, tmp))
         if (!is.null(phy$root.edge)) tmp[1L] <- sprintf(f.d, phy$root.edge)
         INTS <- paste0(INTS, tmp)


### PR DESCRIPTION
Hello Emmanuel, 

I found a bug in `.write.tree2`, which appears if one rotates some edges: 
```
> library(ape)
> set.seed(42)
> tree1 <- rcoal(5)
> tree2 <- rotate(tree1, 7)
> tree2 <- rotate(tree2, 8)
> tree3 <- read.tree(text=write.tree(tree2))
> all.equal(tree1, tree2)
[1] TRUE
> all.equal(tree1, tree3)
[1] FALSE
> all.equal(tree2, tree3)
[1] FALSE
```
This pull request should fix the bug. 

Cheers, 
Klaus