### PR TITLE
consensus did not use postprocess.prop.part and might scramble nodela…

### DIFF
--- a/R/dist.topo.R
+++ b/R/dist.topo.R
@@ -420,6 +420,10 @@ consensus <- function(..., p = 1, check.labels = TRUE, rooted = FALSE)
     ntree <- length(obj)
     ## Get all observed partitions and their frequencies:
     pp <- prop.part(obj, check.labels = FALSE)
+    if (!rooted) {
+        pp <- postprocess.prop.part(pp, "SHORTwise")
+        pp[[1]] <- seq_along(labels)
+    }
     ## Drop the partitions whose frequency is less than 'p':
     if (p == 0.5) p <- 0.5000001 # avoid incompatible splits
     bs <- attr(pp, "number")
@@ -440,6 +444,10 @@ consensus <- function(..., p = 1, check.labels = TRUE, rooted = FALSE)
         pos <- 1L
         foo(1, nextnode)
     }
-    structure(list(edge = edge, tip.label = labels, node.label = bs/ntree,
-              Nnode = m), class = "phylo")
+    res <- structure(list(edge = edge, tip.label = labels,
+                          Nnode = m), class = "phylo")
+    res <- reorder(res)
+    node.label <- prop.clades(res, obj, rooted=rooted)/ntree
+    res$node.label <- node.label
+    res
 }


### PR DESCRIPTION
Dear Emmanuel, 
consensus did not use `postprocess.prop.part` for unrooted trees (so a few bs values might be higher now) and might scramble `node.labels`. I added a `prop.clades` in the end. Might not be the most efficient idea, but it should do the job.
Regards, 
Klaus  