### PR TITLE
make drop.tip and keep.tip generic

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,7 @@ Authors@R: c(person("Emmanuel", "Paradis", role = c("aut", "cre", "cph"), email 
   person("Damien", "de Vienne", role = c("aut", "cph"), comment = c(ORCID = "0000-0001-9532-5251")))
 Depends: R (>= 3.2.0)
 Suggests: gee, expm, igraph, phangorn, testthat (>= 3.0), vdiffr (>= 1.0)
-Imports: nlme, lattice, graphics, methods, stats, tools, utils, parallel, Rcpp (>= 0.12.0)
+Imports: nlme, lattice, graphics, methods, stats, tools, utils, parallel, Rcpp (>= 0.12.0), digest
 LinkingTo: Rcpp
 ZipData: no
 Description: Functions for reading, writing, plotting, and manipulating phylogenetic trees, analyses of comparative data in a phylogenetic framework, ancestral character analyses, analyses of diversification and macroevolution, computing distances from DNA sequences, reading and writing nucleotide sequences as well as importing from BioConductor, and several tools such as Mantel's test, generalized skyline plots, graphical exploration of phylogenetic data (alex, trex, kronoviz), estimation of absolute evolutionary rates and clock-like trees using mean path lengths and penalized likelihood, dating trees with non-contemporaneous sequences, translating DNA into AA sequences, and assessing sequence alignments. Phylogeny estimation can be done with the NJ, BIONJ, ME, MVR, SDM, and triangle methods, and several methods handling incomplete distance matrices (NJ*, BIONJ*, MVR*, and the corresponding triangle method). Some functions call external applications (PhyML, Clustal, T-Coffee, Muscle) whose results are returned into R.

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -30,7 +30,8 @@ export(.compressTipLabel, .PlotPhyloEnv, .uncompressTipLabel,
        di2multi.multiPhylo, di2multi.phylo, dist.aa, dist.dna,
        dist.gene, dist.nodes, dist.topo, diversi.gof, diversi.time,
        diversity.contrast.test, DNAbin2indel, dnds,
-       drawSupportOnEdges, drop.fossil, drop.tip, dyule, edgelabels,
+       drawSupportOnEdges, drop.fossil, drop.tip, drop.tip.phylo,
+       drop.tip.multiPhylo, dyule, edgelabels,
        edges, editFileExtensions, efastats, estimate.dates,
        estimate.mu, evonet, ewLasso, extract.clade, extract.popsize,
        fancyarrows, fastme.bal, fastme.ols, find.skyline.epsilon,
@@ -41,6 +42,7 @@ export(.compressTipLabel, .PlotPhyloEnv, .uncompressTipLabel,
        is.compatible.bitsplits, is.monophyletic, is.rooted,
        is.rooted.multiPhylo, is.rooted.phylo, is.ultrametric,
        is.ultrametric.multiPhylo, is.ultrametric.phylo, keep.tip,
+       keep.tip.phylo, keep.tip.multiPhylo,
        kronoviz, label2table, labels.DNAbin, ladderize, LargeNumber,
        latag2n, letterconf, lmorigin, LTT, ltt.coplot, ltt.lines,
        ltt.plot, ltt.plot.coords, makeChronosCalib, makeLabel,
@@ -168,9 +170,11 @@ S3method("$", multiPhylo)
 S3method("$<-", multiPhylo)
 S3method(c, multiPhylo)
 S3method(di2multi, multiPhylo)
+S3method(drop.tip, multiPhylo)
 S3method(is.binary, multiPhylo)
 S3method(is.rooted, multiPhylo)
 S3method(is.ultrametric, multiPhylo)
+S3method(keep.tip, multiPhylo)
 S3method(makeLabel, multiPhylo)
 S3method(multi2di, multiPhylo)
 S3method(Nedge, multiPhylo)
@@ -193,10 +197,12 @@ S3method(c, phylo)
 S3method(cophenetic, phylo)
 S3method(degree, phylo)
 S3method(di2multi, phylo)
+S3method(drop.tip, phylo)
 S3method(identify, phylo)
 S3method(is.binary, phylo)
 S3method(is.rooted, phylo)
 S3method(is.ultrametric, phylo)
+S3method(keep.tip, phylo)
 S3method(makeLabel, phylo)
 S3method(multi2di, phylo)
 S3method(Nedge, phylo)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -79,6 +79,7 @@ export(.compressTipLabel, .PlotPhyloEnv, .uncompressTipLabel,
        zoom, node_depth, node_depth_edgelength, node_height,
        node_height_clado, seq_root2tip)
 
+importFrom(digest, digest)
 importFrom(graphics, abline, arrows, axTicks, axis, barplot, boxplot, bxp,
            close.screen, identify, image, image.default, layout, legend,
            lines, locator, mtext, par, plot, plot.default, points, polygon,

--- a/R/drop.tip.R
+++ b/R/drop.tip.R
@@ -271,6 +271,11 @@ drop.tip.phylo <-
 
 
 drop.tip.multiPhylo <- function(phy, tip, ...){
+    if (hasArg(interactive))
+        interactive <- list(...)$interactive
+    else interactive <- FALSE
+    if (interactive)
+        stop("interactive=TRUE does not work for drop.tip.multiPhylo.")
     if(is.null(attr(phy, "TipLabel"))){
         tmp <- try(.compressTipLabel(phy), TRUE)
         if(!inherits(tmp, "try-error")) phy <- tmp

--- a/R/drop.tip.R
+++ b/R/drop.tip.R
@@ -7,7 +7,9 @@
 ## This file is part of the R-package `ape'.
 ## See the file ../COPYING for licensing issues.
 
-keep.tip <- function(phy, tip)
+keep.tip <- function(phy, tip, ...) UseMethod("keep.tip")
+
+keep.tip.phylo <- function(phy, tip, ...)
 {
     if (!inherits(phy, "phylo"))
         stop("object \"phy\" is not of class \"phylo\"")
@@ -35,6 +37,25 @@ keep.tip <- function(phy, tip)
     drop.tip(phy, toDrop)
 }
 
+keep.tip.multiPhylo <- function(phy, tip, ...){
+    if(is.null(attr(phy, "TipLabel"))){
+        tmp <- try(.compressTipLabel(phy), TRUE)
+        if(!inherits(tmp, "try-error")) phy <- tmp
+    }
+    if(!is.null(attr(phy, "TipLabel"))){
+        phy <- lapply(phy, keep.tip, tip)
+        class(phy) <- "multiPhylo"
+        phy <- .compressTipLabel(phy)
+    } else {
+        if(!inherits(tip, "character"))
+            stop("Trees have different labels, tip needs to be of class character!")
+        phy <- lapply(phy, keep.tip, tip)
+        class(phy) <- "multiPhylo"
+    }
+    phy
+}
+
+
 extract.clade <- function(phy, node, root.edge = 0, collapse.singles = TRUE, interactive = FALSE)
 {
     n <- length(phy$tip.label)
@@ -61,7 +82,10 @@ extract.clade <- function(phy, node, root.edge = 0, collapse.singles = TRUE, int
              collapse.singles = collapse.singles)
 }
 
-drop.tip <-
+
+drop.tip <- function(phy, tip, ...) UseMethod("drop.tip")
+
+drop.tip.phylo <-
     function(phy, tip, trim.internal = TRUE, subtree = FALSE,
              root.edge = 0, rooted = is.rooted(phy), collapse.singles = TRUE,
              interactive = FALSE)
@@ -241,5 +265,25 @@ drop.tip <-
     if (!is.null(phy$node.label)) # update node.label if needed
         phy$node.label <- phy$node.label[which(newNb > 0) - Ntip]
     if (collapse.singles) phy <- collapse.singles(phy)
+    phy
+}
+
+
+
+drop.tip.multiPhylo <- function(phy, tip, ...){
+    if(is.null(attr(phy, "TipLabel"))){
+        tmp <- try(.compressTipLabel(phy), TRUE)
+        if(!inherits(tmp, "try-error")) phy <- tmp
+    }
+    if(!is.null(attr(phy, "TipLabel"))){
+        phy <- lapply(phy, drop.tip, tip, ...)
+        class(phy) <- "multiPhylo"
+        phy <- .compressTipLabel(phy)
+    } else {
+        if(!inherits(tip, "character"))
+            stop("Trees have different labels, tip needs to be of class character!")
+        phy <- lapply(phy, drop.tip, tip, ...)
+        class(phy) <- "multiPhylo"
+    }
     phy
 }

--- a/R/makeNodeLabel.R
+++ b/R/makeNodeLabel.R
@@ -7,6 +7,12 @@
 ## This file is part of the R-package `ape'.
 ## See the file ../COPYING for licensing issues.
 
+# relabel derived from dist.topo.R inside .compressTipLabel,
+# with an extra argument.
+# makeNodeLabel is faster:
+# 1. use relabel to avoid calling sort inside the loop
+# 2. use digest package to avoid writing files files as with md5sum
+# the node labels are the same
 makeNodeLabel <- function(phy, method = "number", prefix = "Node",
                           nodeList = list(), ...)
 {
@@ -17,18 +23,16 @@ makeNodeLabel <- function(phy, method = "number", prefix = "Node",
         phy$node.label <- paste(prefix, 1:phy$Nnode, sep = "")
 
     if ("md5sum" %in% method) {
+        phy <- relabel(phy, sort(phy$tip.label))
         nl <- character(phy$Nnode)
         pp <- prop.part(phy, check.labels = FALSE)
         labs <- attr(pp, "labels")
-        fl <- tempfile()
         for (i in seq_len(phy$Nnode)) {
-            cat(sort(labs[pp[[i]]]), sep = "\n", file = fl)
-            nl[i] <- tools::md5sum(fl)
+            tmp <- paste0(labs[pp[[i]]], sep="\n", collapse = "")
+            nl[i] <- digest(tmp, algo="md5", serialize = FALSE)
         }
-        unlink(fl)
         phy$node.label <- nl
     }
-
     if ("user" %in% method) {
         if (is.null(phy$node.label))
             phy$node.label <- character(phy$Nnode)
@@ -58,3 +62,23 @@ makeNodeLabel <- function(phy, method = "number", prefix = "Node",
     }
     phy
 }
+
+
+relabel <- function (y, ref, tip.label=TRUE) {
+    label <- y$tip.label
+    if (!identical(label, ref)) {
+        if (length(label) != length(ref))
+            stop("one tree has a different number of tips")
+        ilab <- match(label, ref)
+        if (any(is.na(ilab)))
+            stop("one tree has different tip labels")
+        ie <- match(seq_len(Ntip(y)), y$edge[, 2])
+        y$edge[ie, 2] <- ilab
+    }
+    if(tip.label) y$tip.label <- ref
+    else  y$tip.label <- NULL
+    y
+}
+
+
+

--- a/man/drop.tip.Rd
+++ b/man/drop.tip.Rd
@@ -12,10 +12,14 @@
   from a given node, and deletes all the other tips.
 }
 \usage{
-drop.tip(phy, tip, trim.internal = TRUE, subtree = FALSE,
+drop.tip(phy, tip, ...)
+\method{drop.tip}{phylo}(phy, tip, trim.internal = TRUE, subtree = FALSE,
          root.edge = 0, rooted = is.rooted(phy), collapse.singles = TRUE,
-         interactive = FALSE)
-keep.tip(phy, tip)
+         interactive = FALSE, ...)
+\method{drop.tip}{multiPhylo}(phy, tip, ...)
+keep.tip(phy, tip, ...)
+\method{keep.tip}{phylo}(phy, tip, ...)
+\method{keep.tip}{multiPhylo}(phy, tip, ...)
 extract.clade(phy, node, root.edge = 0, collapse.singles = TRUE,
               interactive = FALSE)
 }


### PR DESCRIPTION
Hello @emmanuelparadis and @liamrevell,
here is some code which should make `drop.tip` and `keep.tip` generic. I realized Liam had a function `drop.tip.multiPhylo`, but I think the changes would not harm this. `drop.tip.multiSimmap` should also work calling `drop.tip` afterwards, but I think this needs some testing.  `drop.tip.multiPhylo` in `phytools` could be dropped later on when `ape` is on CRAN. 
Have nice holidays, 
Klaus 
