### PR TITLE
fix: Add dependency on R 4.1.0 because of native pipe usage

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Authors@R: c(person("Emmanuel", "Paradis", role = c("aut", "cre", "cph"), email 
   person("Klaus", "Schliep", role = c("aut", "cph"), comment = c(ORCID = "0000-0003-2941-0161")),
   person("Korbinian", "Strimmer", role = c("aut", "cph"), comment = c(ORCID = "0000-0001-7917-2056")),
   person("Damien", "de Vienne", role = c("aut", "cph"), comment = c(ORCID = "0000-0001-9532-5251")))
-Depends: R (>= 4.1.0)
+Depends: R (>= 3.2.0)
 Suggests: gee, expm, igraph, phangorn
 Imports: nlme, lattice, graphics, methods, stats, utils, parallel, Rcpp (>= 0.12.0), digest
 LinkingTo: Rcpp

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Authors@R: c(person("Emmanuel", "Paradis", role = c("aut", "cre", "cph"), email 
   person("Klaus", "Schliep", role = c("aut", "cph"), comment = c(ORCID = "0000-0003-2941-0161")),
   person("Korbinian", "Strimmer", role = c("aut", "cph"), comment = c(ORCID = "0000-0001-7917-2056")),
   person("Damien", "de Vienne", role = c("aut", "cph"), comment = c(ORCID = "0000-0001-9532-5251")))
-Depends: R (>= 3.2.0)
+Depends: R (>= 4.1.0)
 Suggests: gee, expm, igraph, phangorn
 Imports: nlme, lattice, graphics, methods, stats, utils, parallel, Rcpp (>= 0.12.0), digest
 LinkingTo: Rcpp

--- a/R/rtt.R
+++ b/R/rtt.R
@@ -34,7 +34,7 @@ rtt <- function (t, tip.dates, ncpu = 1, objective = "correlation",
         objective <- function(x, y) {
             # summary(lm(y ~ x))$r.squared
             X[,2] <- x
-            lm.fit(X, y) |> r.squared()
+            r.squared(lm.fit(X, y))
         }
     else if (objective == "rms"){
         objective <- function(x, y){


### PR DESCRIPTION
Fix #67

:wave: here, thanks for your work on {ape}!

In https://github.com/emmanuelparadis/ape/blob/0031c04bcafc9b9e387829c9b6441c9fc4ff008d/R/rtt.R#L37 the native pipe is used, so in practice {ape} should depend on R >= 4.1.0. :smile_cat: 