### PR TITLE
Specify class in .uncompressTipLabel

### DIFF
--- a/R/dist.topo.R
+++ b/R/dist.topo.R
@@ -193,8 +193,6 @@ prop.part <- function(..., check.labels = TRUE)
     for (i in 1:ntree) storage.mode(obj[[i]]$Nnode) <- "integer"
     class(obj) <- "multiPhylo"
     obj <- reorder(obj, "postorder")
-# the following line should not be necessary any more
-#    obj <- .uncompressTipLabel(obj) # fix a bug (2010-11-18)
     nTips <- length(obj[[1]]$tip.label)
     clades <- prop_part2(obj, nTips)
     attr(clades, "labels") <- obj[[1]]$tip.label
@@ -327,8 +325,8 @@ boot.phylo <-
     ## sort labels after mixed them up
     if (jumble) {
         boot.tree <- .compressTipLabel(boot.tree, ref = phy$tip.label)
-        boot.tree <- .uncompressTipLabel(boot.tree)
-        boot.tree <- unclass(boot.tree) # otherwise countBipartitions crashes
+        # class = NULL, otherwise countBipartitions crashes
+        boot.tree <- .uncompressTipLabel(boot.tree, class = NULL)
     }
     class(boot.tree) <- "multiPhylo"
     if (rooted) {

--- a/R/summary.phylo.R
+++ b/R/summary.phylo.R
@@ -211,7 +211,7 @@ c.multiPhylo <- function(..., recursive = TRUE)
     .makeMultiPhyloFromObj(obj)
 }
 
-.uncompressTipLabel <- function(x, class = class(x))
+.uncompressTipLabel <- function(x, class = attr(x, "class"))
 {
     Lab <- attr(x, "TipLabel")
     if (is.null(Lab)) return(x)
@@ -250,8 +250,7 @@ c.multiPhylo <- function(..., recursive = TRUE)
 
     ## to solve PR #45
     if (is.null(TipLabel.value)) {
-        x <- .uncompressTipLabel(x)
-        class(x) <- NULL
+        x <- .uncompressTipLabel(x, class = NULL)
     } else {
         if (!identical(TipLabel.x, TipLabel.value)) {
             x <- .uncompressTipLabel(x, class = NULL)

--- a/R/summary.phylo.R
+++ b/R/summary.phylo.R
@@ -162,7 +162,9 @@ c.phylo <- function(..., recursive = TRUE)
     if (all(isphylo | ismulti)) {
         for (i in which(isphylo)) obj[[i]] <- .c_phylo_single(obj[[i]])
         ## added by Klaus:
-        for (i in which(ismulti)) obj[[i]] <- .uncompressTipLabel(obj[[i]])
+        for (i in which(ismulti)) {
+          obj[[i]] <- .uncompressTipLabel(obj[[i]], class = "multiPhylo")
+        }
         obj <- .makeMultiPhyloFromObj(obj)
     } else {
         warning('some objects not of class "phylo" or "multiPhylo": argument recursive=TRUE ignored')
@@ -203,17 +205,21 @@ c.multiPhylo <- function(..., recursive = TRUE)
     }
     for (i in which(isphylo)) obj[[i]] <- .c_phylo_single(obj[[i]])
     ## added by Klaus
-    for (i in which(ismulti)) obj[[i]] <- .uncompressTipLabel(obj[[i]])
+    for (i in which(ismulti)) {
+      obj[[i]] <- .uncompressTipLabel(obj[[i]], class = "multiPhylo")
+    }
     .makeMultiPhyloFromObj(obj)
 }
 
-.uncompressTipLabel <- function(x)
+.uncompressTipLabel <- function(x, class = class(x))
 {
     Lab <- attr(x, "TipLabel")
     if (is.null(Lab)) return(x)
     class(x) <- NULL
     for (i in 1:length(x)) x[[i]]$tip.label <- Lab
-    class(x) <- "multiPhylo"
+    if (!is.null(class)) {
+      class(x) <- class
+    }
     attr(x, "TipLabel") <- NULL
     x
 }
@@ -248,8 +254,7 @@ c.multiPhylo <- function(..., recursive = TRUE)
         class(x) <- NULL
     } else {
         if (!identical(TipLabel.x, TipLabel.value)) {
-            x <- .uncompressTipLabel(x)
-            class(x) <- NULL
+            x <- .uncompressTipLabel(x, class = NULL)
             value <- .uncompressTipLabel(value)
         }
     }

--- a/R/write.nexus.R
+++ b/R/write.nexus.R
@@ -44,7 +44,7 @@ write.nexus <- function(..., file = "", translate = TRUE)
                 obj[[i]]$tip.label <- checkLabel(obj[[i]]$tip.label)
         } else {
             attr(obj, "TipLabel") <- checkLabel(attr(obj, "TipLabel"))
-            obj <- .uncompressTipLabel(obj)
+            obj <- .uncompressTipLabel(obj, class = "multiPhylo")
         }
     }
 

--- a/R/write.tree.R
+++ b/R/write.tree.R
@@ -53,8 +53,7 @@ write.tree <-
     }
 
     ## added by EP (2019-01-23):
-    phy <- .uncompressTipLabel(phy)
-    class(phy) <- NULL
+    phy <- .uncompressTipLabel(phy, class = NULL)
 
     for (i in 1:N)
         res[i] <- .write.tree2(phy[[i]], digits = digits,

--- a/man/c.phylo.Rd
+++ b/man/c.phylo.Rd
@@ -11,7 +11,7 @@
 \method{c}{phylo}(..., recursive = TRUE)
 \method{c}{multiPhylo}(..., recursive = TRUE)
 .compressTipLabel(x, ref = NULL)
-.uncompressTipLabel(x)
+.uncompressTipLabel(x, class = class(x))
 }
 \arguments{
   \item{\dots}{one or several objects of class \code{"phylo"} and/or
@@ -20,6 +20,8 @@
   \item{x}{an object of class \code{"phylo"} or \code{"multiPhylo"}.}
   \item{ref}{an optional vector of mode character to constrain the order
     of the tips. By default, the order from the first tree is used.}
+  \item{class}{character vector stipulating the class to assign to the returned
+  object.}
 }
 \details{
   These \code{c} methods check all the arguments, and return by default
@@ -39,7 +41,8 @@
   \code{.uncompressTipLabel} does the reverse operation.
 }
 \value{
-  An object of class \code{"multiPhylo"}.
+  An object of class \code{"multiPhylo"} (or, if \code{class} is specified, of
+  class \code{class}).
 }
 \author{Emmanuel Paradis}
 \seealso{\code{\link{summary.phylo}}, \code{\link{multiphylo}}}


### PR DESCRIPTION
Hi Emmanuel,

I'm currently debugging an [error](https://cran.r-project.org/web/checks/check_results_TreeSearch.html) that's arisen in the TreeSearch package with a recent update to R devel.

The error arises when I call `tree[] <- value` with a "multiPhylo" object.
If I instead run
```r
at <- attributes(tree)
tree <- value
attributes(tree) <- at
```
then I don't encounter the issue. 

I can't quite pin down what the underlying issue is here, though – there's a degree of stochasticity that makes the bug difficult to reproduce.  Indeed I'm not yet sure whether the issue lies with ape, TreeSearch, or R itself...

In any case, I've been working through the ape source to try to get to the bottom of the issue, and spotted a couple of opportunities to streamline / improve clarity.

This PR looks to simplify the code by removing the need to unclass objects that have just been unnecessarily classed as "multiPhylo" in `.uncompressTipLabel()`.