### PR TITLE
`1:length(x)` → `seq_along(x)`

### DIFF
--- a/R/summary.phylo.R
+++ b/R/summary.phylo.R
@@ -212,7 +212,7 @@ c.multiPhylo <- function(..., recursive = TRUE)
     Lab <- attr(x, "TipLabel")
     if (is.null(Lab)) return(x)
     class(x) <- NULL
-    for (i in 1:length(x)) x[[i]]$tip.label <- Lab
+    for (i in seq_along(x)) x[[i]]$tip.label <- Lab
     class(x) <- "multiPhylo"
     attr(x, "TipLabel") <- NULL
     x


### PR DESCRIPTION
- robust to length zero objects
- marginally faster