### PR TITLE
improve keep.tip and drop.tip

### DIFF
--- a/R/drop.tip.R
+++ b/R/drop.tip.R
@@ -7,9 +7,9 @@
 ## This file is part of the R-package `ape'.
 ## See the file ../COPYING for licensing issues.
 
-keep.tip <- function(phy, tip) UseMethod("keep.tip")
+keep.tip <- function(phy, tip, ...) UseMethod("keep.tip")
 
-keep.tip.phylo <- function(phy, tip)
+keep.tip.phylo <- function(phy, tip, ...)
 {
 ###    if (!inherits(phy, "phylo"))
 ###        stop("object \"phy\" is not of class \"phylo\"")
@@ -34,7 +34,7 @@ keep.tip.phylo <- function(phy, tip)
     }
     ## get complement tip indices to drop
     toDrop <- setdiff(1:Ntip, tip)
-    drop.tip(phy, toDrop)
+    drop.tip(phy, toDrop, ...)
 }
 
 extract.clade <- function(phy, node, root.edge = 0, collapse.singles = TRUE, interactive = FALSE)
@@ -218,7 +218,7 @@ drop.tip.phylo <- function(phy, tip, trim.internal = TRUE, subtree = FALSE,
         new.tip.label <-
             if (!length(node2tip)) {
                 character(0)
-            } else if (subtree) {
+            } else if (subtree && is.null(phy$node.label)) {
                 paste("[", N[node2tip], "_tips]", sep = "")
             } else {
                 if (is.null(phy$node.label)) rep("NA", length(node2tip))
@@ -248,20 +248,20 @@ drop.tip.phylo <- function(phy, tip, trim.internal = TRUE, subtree = FALSE,
 
 ## "multiPhylo" methods by Klaus:
 
-keep.tip.multiPhylo <- function(phy, tip)
+keep.tip.multiPhylo <- function(phy, tip, ...)
 {
     if (is.null(attr(phy, "TipLabel"))) {
         tmp <- try(.compressTipLabel(phy), TRUE)
         if (!inherits(tmp, "try-error")) phy <- tmp
     }
     if (!is.null(attr(phy, "TipLabel"))) {
-        phy <- lapply(phy, keep.tip, tip)
+        phy <- lapply(phy, keep.tip, tip, ...)
         class(phy) <- "multiPhylo"
         phy <- .compressTipLabel(phy)
     } else {
         if (!inherits(tip, "character"))
             stop("Trees have different labels, tip needs to be of class character!")
-        phy <- lapply(phy, keep.tip, tip)
+        phy <- lapply(phy, keep.tip, tip, ...)
         class(phy) <- "multiPhylo"
     }
     phy

--- a/man/drop.tip.Rd
+++ b/man/drop.tip.Rd
@@ -22,9 +22,9 @@ drop.tip(phy, tip, \dots)
          interactive = FALSE, \dots)
 \method{drop.tip}{multiPhylo}(phy, tip, \dots)
 
-keep.tip(phy, tip)
-\method{keep.tip}{phylo}(phy, tip)
-\method{keep.tip}{multiPhylo}(phy, tip)
+keep.tip(phy, tip, ...)
+\method{keep.tip}{phylo}(phy, tip, ...)
+\method{keep.tip}{multiPhylo}(phy, tip, ...)
 
 extract.clade(phy, node, root.edge = 0, collapse.singles = TRUE,
               interactive = FALSE)
@@ -67,9 +67,9 @@ extract.clade(phy, node, root.edge = 0, collapse.singles = TRUE,
   are used.
 
   If \code{subtree = TRUE}, the returned tree has one or several
-  terminal branches indicating how many tips have been removed (with a
-  label \code{"[x_tips]"}). This is done for as many monophyletic groups
-  that have been deleted.
+  terminal branches named with node labels if available. Otherwise it is
+  indicated how many tips have been removed (with a label \code{"[x_tips]"}).
+  This is done for as many monophyletic groups that have been deleted.
 
   Note that \code{subtree = TRUE} implies \code{trim.internal = TRUE}.
 


### PR DESCRIPTION
Hello @emmanuelparadis, 
this is a small improvement to `keep.tip` and `drop.tip` following the discussion with @HedvigS. It allows to use all arguments of `drop.tip` in `keep.tip` via the `...` argument. It changes the behaviour of `drop.tip`, which uses node labels if available when `subtree = TRUE`. I assume this is not likely breaking any code, even though it changes the return values slightly. However currently the node labels returned are not necessarily unique. 
Kind regards, 
Klaus      