### PR TITLE
Handle zero-leaf trees

### DIFF
--- a/R/collapse.singles.R
+++ b/R/collapse.singles.R
@@ -21,6 +21,9 @@ has.singles <- function(tree)
 collapse.singles <- function(tree, root.edge = FALSE)
 {
     n <- length(tree$tip.label)
+    if (n == 0) {
+        return(tree)
+    }
     tree <- reorder(tree) # this works now
     e1 <- tree$edge[, 1]
     e2 <- tree$edge[, 2]

--- a/R/reorder.phylo.R
+++ b/R/reorder.phylo.R
@@ -42,7 +42,12 @@ reorder.phylo <- function(x, order = "cladewise", index.only = FALSE, ...)
     io <- pmatch(order, ORDER)
     if (is.na(io)) stop("ambiguous order")
     order <- ORDER[io]
-    .reorder_ape(x, order, index.only, length(x$tip.label), io)
+    n <- length(x$tip.label)
+    if (n < 2) {
+        x
+    } else {
+        .reorder_ape(x, order, index.only, n, io)
+    }
 }
 
 reorder.multiPhylo <- function(x, order = "cladewise", ...)


### PR DESCRIPTION
Some operations can produce zero-leaf trees: for example, reducing a pair of trees by retaining only the leaves they hold in common.

Such zero-leaf trees throw errors in certain ape functions, where it would be appropriate to silently return the zero-leaf tree that was input.

I have proposed modifications to the two functions that have been causing issues where they are called in downstream functions in TreeTools and TreeDist – though there may be mileage in handling this case safely in other functions too.