### PR TITLE
Added a multiPhylo case to makeNodeLabel

### DIFF
--- a/R/makeNodeLabel.R
+++ b/R/makeNodeLabel.R
@@ -17,6 +17,14 @@
 makeNodeLabel <- function(phy, method = "number", prefix = "Node",
                           nodeList = list(), ...)
 {
+    ## multiPhylo
+    if(is(phy, "multiPhylo")) {
+        phy <- lapply(phy, makeNodeLabel, method, prefix, nodeList, ...)
+        class(phy) <- "multiPhylo"
+        return(phy)
+    }
+
+    ## phylo
     method <- sapply(method, match.arg, c("number", "md5sum", "user"),
                      USE.NAMES = FALSE)
 


### PR DESCRIPTION
Dear `ape` team,

Here's a quick and easy self call for `makeNodeLabel` to handle the `phy` argument as a `"multiPhylo"` with a mini test below if it's of interest (feel free to reject if not interested!).

Cheers,
Thomas

```
test_that("makeNodeLabel works for phylo and multiPhylo", {
    set.seed(1)
    trees <- rmtree(2, 3)

    ## phylo
    test <- makeNodeLabel(trees[[1]], prefix = "Node")
    expect_is(test, "phylo")
    expect_equal(test$node.label, c("Node1", "Node2"))

    ## multiPhylo (with options parsed correctly)
    test <- makeNodeLabel(trees, prefix = "nOde")
    expect_is(test, "multiPhylo")
   expect_equal(test[[2]]$node.label, c("nOde1", "nOde2"))
})
```