### PR TITLE
Adds node labels to ace output if available

### DIFF
--- a/R/ace.R
+++ b/R/ace.R
@@ -298,6 +298,16 @@ ace <-
             obj$lik.anc <- lik.anc
         }
     }
+
+    ## Adding node labels to $ace and $CI95 (if available)
+    if(!is.null(phy$node.label)) {
+        ordered_node_labels <- phy$node.label[c(as.integer(names(obj$ace))- Ntip(phy))]
+        names(obj$ace) <- ordered_node_labels
+        if(!is.null(obj$CI95)) {
+            rownames(obj$CI95) <- ordered_node_labels
+        }
+    }
+    
     obj$call <- match.call()
     class(obj) <- "ace"
     obj


### PR DESCRIPTION
Hi `ape` team,

This is just a small aesthetic change to `ace` to output estimations with node labels names if the provided `phy` had some. The tests are below (based on the example).

Cheers,
Thomas


```
test_that("adding node labels to ace output works", {
    ## Example with no node labels
    data(bird.orders)
    x <- rnorm(23)
    ### Compare the three methods for continuous characters:
    out <- ace(x, bird.orders)
    expect_equal(names(out$ace), as.character(seq(from = 1+Ntip(bird.orders), to = Nnode(bird.orders)+Ntip(bird.orders))))
    expect_equal(rownames(out$CI95), as.character(seq(from = 1+Ntip(bird.orders), to = Nnode(bird.orders)+Ntip(bird.orders))))

    ## Adding node labels
    phy_nodes <- makeNodeLabel(bird.orders)
    out <- ace(x, phy_nodes)
    expect_equal(names(out$ace), phy_nodes$node.label)
    expect_equal(rownames(out$CI95), phy_nodes$node.label)
})
```