### PR TITLE
Fixed bug and added node label handling for discrete

### DIFF
--- a/R/ace.R
+++ b/R/ace.R
@@ -301,9 +301,12 @@ ace <-
 
     ## edited from Thomas G (PR #106):
     if (!is.null(phy$node.label)) {
-        names(obj$ace) <- phy$node.label
+        if (!is.null(obj$ace))
+            names(obj$ace) <- phy$node.label
         if (!is.null(obj$CI95))
             rownames(obj$CI95) <- phy$node.label
+        if (!is.null(obj$lik.anc)) 
+            rownames(obj$lik.anc) <- phy$node.label
     }
 
     obj$call <- match.call()

--- a/R/makeNodeLabel.R
+++ b/R/makeNodeLabel.R
@@ -20,14 +20,6 @@ makeNodeLabel.phylo <-
     function(phy, method = "number", prefix = "Node",
              nodeList = list(), ...)
 {
-    ## multiPhylo
-    if(is(phy, "multiPhylo")) {
-        phy <- lapply(phy, makeNodeLabel, method, prefix, nodeList, ...)
-        class(phy) <- "multiPhylo"
-        return(phy)
-    }
-
-    ## phylo
     method <- sapply(method, match.arg, c("number", "md5sum", "user"),
                      USE.NAMES = FALSE)
 


### PR DESCRIPTION
My previous PR seemed to have included a bug when using trees with node labels and doing ace for discrete data ([guessing from here](https://stackoverflow.com/questions/78570454/error-when-attempting-to-run-equal-rates-ancestral-character-estimation)).

Here's a quick fix and the test for discrete characters for next release.

```
test_that("adding node labels to ace output works for discrete characters", {
    ## Example with no node labels
    data(bird.orders)
    x <- as.factor(c(rep(0, 5), rep(1, 18)))
    ### Compare the three methods for continuous characters:
    out <- ace(x, bird.orders, type = "d")
    expect_equal(rownames(out$lik.anc), as.character(seq(from = 1+Ntip(bird.orders), to = Nnode(bird.orders)+Ntip(bird.orders))))

    ## Adding node labels
    phy_nodes <- makeNodeLabel(bird.orders)
    out <- ace(x, phy_nodes, type = "d")
    expect_equal(rownames(out$lik.anc), phy_nodes$node.label)
})
```