### PR TITLE
Improve write.tree and write.nexus. 

### DIFF
--- a/R/plot.phylo.R
+++ b/R/plot.phylo.R
@@ -893,12 +893,26 @@ trex <- function(phy, title = TRUE, subbg = "lightyellow3",
     }
 }
 
-kronoviz <- function(x, layout = length(x), horiz = TRUE, ...)
+kronoviz <- function(x, layout = length(x), horiz = TRUE, ..., 
+                     direction = ifelse(horiz, "rightwards", "upwards"), side=2)
 {
+    op <- par(no.readonly = TRUE)
+    on.exit({
+      par(op)
+      devAskNewPage(FALSE)
+    })
     par(mar = rep(0.5, 4), oma = rep(2, 4))
+    direction <- match.arg(direction, c("rightwards", "leftwards",
+                                          "upwards", "downwards"))
+    horiz <- ifelse(direction %in% c("rightwards", "leftwards"), TRUE, FALSE) 
+
     rts <- sapply(x, function(x) branching.times(x)[1])
     maxrts <- max(rts)
     lim <- cbind(rts - maxrts, rts)
+    if(direction %in% c("leftwards", "downwards")){
+      lim[,1] <- 0
+      lim[,2] <- maxrts  
+    }
     Ntree <- length(x)
     Ntips <- sapply(x, Ntip)
     if (horiz) {
@@ -913,16 +927,20 @@ kronoviz <- function(x, layout = length(x), horiz = TRUE, ...)
     layout(matrix(1:layout, nrow), widths = w, heights = h)
     if (layout < Ntree && !devAskNewPage() && interactive()) {
         devAskNewPage(TRUE)
-        on.exit(devAskNewPage(FALSE))
     }
     if (horiz) {
-        for (i in 1:Ntree)
-            plot(x[[i]], x.lim = lim[i, ], ...)
+        for (i in 1:Ntree){
+            plot(x[[i]], x.lim = lim[i, ], direction = direction, ...)
+            if(i == 1 && 1 %in% side) axisPhylo(side=3)
+        }
     } else {
-        for (i in 1:Ntree)
-            plot(x[[i]], y.lim = lim[i, ], direction = "u", ...)
+        for (i in 1:Ntree){
+            plot(x[[i]], y.lim = lim[i, ], direction = direction, ...)
+            if(i == 1 && 1 %in% side) axisPhylo(side=2)
+        }
     }
-    axisPhylo(if (horiz) 1 else 4) # better if the deepest tree is last ;)
+    if(2 %in% side)axisPhylo(if (horiz) 1 else 4)
+    invisible(x)
 }
 
 tidy.xy <- function(edge, Ntip, Nnode, xx, yy)

--- a/R/scales.R
+++ b/R/scales.R
@@ -72,72 +72,91 @@ add.scale.bar <- function(x, y, length = NULL, ask = FALSE,
            })
 }
 
-axisPhylo <- function(side = 1, root.time = NULL, backward = TRUE, ...)
+axisPhylo <- function(side = NULL, root.time = NULL, backward = TRUE, ...)
 {
-    lastPP <- get("last_plot.phylo", envir = .PlotPhyloEnv)
-    type <- lastPP$type
-
-    if (type == "unrooted")
-        stop("axisPhylo() not available for unrooted plots; try add.scale.bar()")
-    if (type == "radial")
-        stop("axisPhylo() not meaningful for this type of plot")
-
-    if (is.null(root.time)) root.time <- lastPP$root.time
-
-    if (type %in% c("phylogram", "cladogram")) {
-        xscale <-
-            if (lastPP$direction %in% c("rightwards", "leftwards")) range(lastPP$xx)
-            else range(lastPP$yy)
-
-        tmp <- lastPP$direction %in% c("leftwards", "downwards")
-
-        tscale <- c(0, xscale[2] - xscale[1])
-        if (xor(backward, tmp)) tscale <- tscale[2:1]
-        if (!is.null(root.time)) {
-            tscale <- tscale + root.time
-            if (backward) tscale <- tscale - xscale[2]
-        }
-
-        ## the linear transformation between the x-scale and the time-scale:
-        beta <- diff(xscale) / diff(tscale)
-        alpha <- xscale[1] - beta * tscale[1]
-
-        lab <- pretty(tscale)
-        x <- beta * lab + alpha
-        axis(side = side, at = x, labels = lab, ...)
-    } else { # type == "fan"
-        n <- lastPP$Ntip
-        xx <- lastPP$xx[1:n]; yy <- lastPP$yy[1:n]
-        r0 <- max(sqrt(xx^2 + yy^2))
-
-        ## find the widest angle between tips:
-        alpha <- sort(setNames(rect2polar(xx, yy)$angle, 1:n)) # from -pi to +pi
-        angles <- c(diff(alpha), 2*pi - alpha[n] + alpha[1L])
-        j <- which.max(angles)
-        i <- if (j == 1L) n else j - 1L # this is a circle...
-        firstandlast <- as.integer(names(angles[c(i, j)])) # c(1, n)
-
-        theta0 <- mean(atan2(yy[firstandlast], xx[firstandlast]))
-        x0 <- r0 * cos(theta0); y0 <- r0 * sin(theta0)
-        inc <- diff(pretty(c(0, r0))[1:2])
-        srt <- 360*theta0/(2*pi)
-        coef <- -1
-        if (abs(srt) > 90) {
-            srt <- srt + 180
-            coef <- 1
-        }
-        len <- 0.025 * r0 # the length of tick marks
-        r <- r0
-        while (r > 1e-8) {
-            x <- r * cos(theta0); y <- r * sin(theta0)
-            if (len/r < 1) {
-                ra <- sqrt(len^2 + r^2); thetaa <- theta0 + coef * asin(len/r)
-                xa <- ra * cos(thetaa); ya <- ra * sin(thetaa)
-                segments(xa, ya, x, y)
-                text(xa, ya, r0 - r, srt = srt, adj = c(0.5, 1.1), ...)
-            }
-            r <- r - inc
-        }
-        segments(x, y, x0, y0)
+  lastPP <- get("last_plot.phylo", envir = .PlotPhyloEnv)
+  type <- lastPP$type
+  
+  if (type == "unrooted")
+    stop("axisPhylo() not available for unrooted plots; try add.scale.bar()")
+  if (type == "radial")
+    stop("axisPhylo() not meaningful for this type of plot")
+  
+  if (is.null(root.time)) root.time <- lastPP$root.time
+  
+  if (type %in% c("phylogram", "cladogram")) {
+    if(is.null(side)){
+      if (lastPP$direction %in% c("rightwards", "leftwards")) side <- 1
+      else side <- 2
     }
+    if (lastPP$direction %in% c("rightwards", "leftwards")){
+      tmp_range <- range(lastPP$xx)
+      tmp_lim <- lastPP$x.lim
+    } else {
+      tmp_range <- range(lastPP$yy)
+      tmp_lim <- lastPP$y.lim
+    }
+    
+    if (lastPP$direction == "rightwards"){
+      xscale <- c(min(tmp_lim[1],tmp_range[1]), range(lastPP$xx)[2])
+    }
+    if (lastPP$direction == "leftwards"){
+      xscale <- c(tmp_range[1], max(tmp_range[2], tmp_lim[2]))
+    }
+    if (lastPP$direction == "downwards"){
+      xscale <- c(tmp_range[1], max(tmp_range[2], tmp_lim[2]))
+    }  
+    if (lastPP$direction == "upwards"){  
+      xscale <- c(min(tmp_range[1], tmp_lim[1]), tmp_range[2])
+    }
+    
+    tscale <- xscale 
+    tmp <- lastPP$direction %in% c("leftwards", "downwards")
+    if (xor(backward, tmp))  tscale <- tmp_range[2] - tscale  
+    if (!is.null(root.time)) {
+      if(! backward) tscale <- tscale + root.time
+      else tscale <- tscale + root.time - diff(tmp_range)
+    }
+    
+    ## the linear transformation between the x-scale and the time-scale:
+    beta <- diff(xscale) / diff(tscale)
+    alpha <- xscale[1] - beta * tscale[1]
+    lab <- pretty(tscale)
+    x <- beta * lab + alpha
+    axis(side = side, at = x, labels = lab, ...)
+  } else { # type == "fan"
+    n <- lastPP$Ntip
+    xx <- lastPP$xx[1:n]; yy <- lastPP$yy[1:n]
+    r0 <- max(sqrt(xx^2 + yy^2))
+    
+    ## find the widest angle between tips:
+    alpha <- sort(setNames(rect2polar(xx, yy)$angle, 1:n)) # from -pi to +pi
+    angles <- c(diff(alpha), 2*pi - alpha[n] + alpha[1L])
+    j <- which.max(angles)
+    i <- if (j == 1L) n else j - 1L # this is a circle...
+    firstandlast <- as.integer(names(angles[c(i, j)])) # c(1, n)
+    
+    theta0 <- mean(atan2(yy[firstandlast], xx[firstandlast]))
+    x0 <- r0 * cos(theta0); y0 <- r0 * sin(theta0)
+    inc <- diff(pretty(c(0, r0))[1:2])
+    srt <- 360*theta0/(2*pi)
+    coef <- -1
+    if (abs(srt) > 90) {
+      srt <- srt + 180
+      coef <- 1
+    }
+    len <- 0.025 * r0 # the length of tick marks
+    r <- r0
+    while (r > 1e-8) {
+      x <- r * cos(theta0); y <- r * sin(theta0)
+      if (len/r < 1) {
+        ra <- sqrt(len^2 + r^2); thetaa <- theta0 + coef * asin(len/r)
+        xa <- ra * cos(thetaa); ya <- ra * sin(thetaa)
+        segments(xa, ya, x, y)
+        text(xa, ya, r0 - r, srt = srt, adj = c(0.5, 1.1), ...)
+      }
+      r <- r - inc
+    }
+    segments(x, y, x0, y0)
+  }
 }

--- a/R/write.nexus.R
+++ b/R/write.nexus.R
@@ -7,7 +7,7 @@
 ## This file is part of the R-package `ape'.
 ## See the file ../COPYING for licensing issues.
 
-write.nexus <- function(..., file = "", translate = TRUE)
+write.nexus <- function(..., file = "", translate = TRUE, digits=10)
 {
     obj <- .getTreesFromDotdotdot(...)
     ntree <- length(obj)
@@ -59,7 +59,7 @@ write.nexus <- function(..., file = "", translate = TRUE)
         if (!inherits(obj[[i]], "phylo")) next
         root.tag <- if (is.rooted(obj[[i]])) "= [&R] " else "= [&U] "
         cat("\tTREE *", title[i], root.tag, file = file, append = TRUE)
-        cat(write.tree(obj[[i]], file = ""),
+        cat(write.tree(obj[[i]], file = "", digits=digits),
             "\n", sep = "", file = file, append = TRUE)
     }
     cat("END;\n", file = file, append = TRUE)

--- a/R/write.tree.R
+++ b/R/write.tree.R
@@ -66,7 +66,7 @@ write.tree <-
 
 .write.tree2 <- function(phy, digits = 10, tree.prefix = "", check_tips)
 {
-    brl <- !is.null(phy$edge.length)
+    brl <- (!is.null(phy$edge.length) && digits >= 0)
     nodelab <- !is.null(phy$node.label)
     if (check_tips) phy$tip.label <- checkLabel(phy$tip.label)
     if (nodelab) {

--- a/man/axisPhylo.Rd
+++ b/man/axisPhylo.Rd
@@ -2,11 +2,12 @@
 \alias{axisPhylo}
 \title{Axis on Side of Phylogeny}
 \usage{
-axisPhylo(side = 1, root.time = NULL, backward = TRUE, ...)
+axisPhylo(side = NULL, root.time = NULL, backward = TRUE, ...)
 }
 \arguments{
   \item{side}{a numeric value specifying the side where the axis is
-    plotted: 1: below, 2: left, 3: above, 4: right.}
+    plotted: 1: below, 2: left, 3: above, 4: right. By default, this is taken 
+    from the direction of the plot.}
   \item{root.time}{the time assigned to the root node of the tree. By
     default, this is taken from the \code{root.time} element of the
     tree. If it is absent, this is determined from the next option.}
@@ -24,7 +25,7 @@ axisPhylo(side = 1, root.time = NULL, backward = TRUE, ...)
   the help pages on \code{\link[graphics]{axis}} and
   \code{\link[graphics]{par}}).
 }
-\author{Emmanuel Paradis}
+\author{Emmanuel Paradis, Klaus Schliep}
 \seealso{
   \code{\link{plot.phylo}}, \code{\link{add.scale.bar}},
   \code{\link[graphics]{axis}}, \code{\link[graphics]{par}}
@@ -35,6 +36,6 @@ ch <- rcoal(30)
 plot(ch)
 axisPhylo()
 plot(tr, "c", FALSE, direction = "u")
-axisPhylo(2, las = 1)
+axisPhylo(las = 1)
 }
 \keyword{aplot}

--- a/man/kronoviz.Rd
+++ b/man/kronoviz.Rd
@@ -6,7 +6,8 @@
   same scale.
 }
 \usage{
-kronoviz(x, layout = length(x), horiz = TRUE, ...)
+kronoviz(x, layout = length(x), horiz = TRUE, ..., 
+         direction = ifelse(horiz, "rightwards", "upwards"), side=2) 
 }
 \arguments{
   \item{x}{a list of (rooted) trees of class \code{"phylo"}.}
@@ -18,7 +19,7 @@ kronoviz(x, layout = length(x), horiz = TRUE, ...)
   \item{direction}{a character string specifying the direction of the tree. Four
   values are possible: "rightwards" (the default), "leftwards", "upwards", and 
   "downwards".}
-  \item{side} {Where to put the axis, see example.} 
+  \item{side}{Where to put the axis, see example.} 
 }
 \details{
   The size of the individual plots is proportional to the size of the

--- a/man/kronoviz.Rd
+++ b/man/kronoviz.Rd
@@ -15,19 +15,25 @@ kronoviz(x, layout = length(x), horiz = TRUE, ...)
   \item{horiz}{a logical specifying whether the trees should be plotted
     rightwards (the default) or upwards.}
   \item{\dots}{further arguments passed to \code{plot.phylo}.}
+  \item{direction}{a character string specifying the direction of the tree. Four
+  values are possible: "rightwards" (the default), "leftwards", "upwards", and 
+  "downwards".}
+  \item{side} {Where to put the axis, see example.} 
 }
 \details{
   The size of the individual plots is proportional to the size of the
   trees.
 }
 \value{NULL}
-\author{Emmanuel Paradis}
+\author{Emmanuel Paradis, Klaus Schliep}
 \seealso{
   \code{\link{plot.phylo}}
 }
 \examples{
 TR <- replicate(10, rcoal(sample(11:20, size = 1)), simplify = FALSE)
 kronoviz(TR)
+kronoviz(TR, side=1)
 kronoviz(TR, horiz = FALSE, type = "c", show.tip.label = FALSE)
+kronoviz(TR, direction="d", side=c(1,2))
 }
 \keyword{hplot}

--- a/man/write.nexus.Rd
+++ b/man/write.nexus.Rd
@@ -2,7 +2,7 @@
 \alias{write.nexus}
 \title{Write Tree File in Nexus Format}
 \usage{
-write.nexus(..., file = "", translate = TRUE)
+write.nexus(..., file = "", translate = TRUE, digits=10)
 }
 \arguments{
   \item{\dots}{either (i) a single object of class \code{"phylo"}, (ii) a
@@ -14,6 +14,8 @@ write.nexus(..., file = "", translate = TRUE)
   \item{translate}{a logical, if \code{TRUE} (the default) a translation
     of the tip labels is done which are replaced in the parenthetic
     representation with tokens.}
+  \item{digits}{a numeric giving the number of digits used for printing
+    branch lengths. For negative numbers no branch lengths are printed.}
 }
 \description{
   This function writes trees in a file with the NEXUS format.

--- a/man/write.tree.Rd
+++ b/man/write.tree.Rd
@@ -14,7 +14,7 @@ write.tree(phy, file = "", append = FALSE,
     without erasing the data possibly existing in the file, otherwise
     the file (if it exists) is overwritten (\code{FALSE} the default).}
   \item{digits}{a numeric giving the number of digits used for printing
-    branch lengths.}
+    branch lengths. For negative numbers no branch lengths are printed.}
   \item{tree.names}{either a logical or a vector of mode character. If
     \code{TRUE} then any tree names will be written prior to the tree on
     each line. If character, specifies the name of \code{"phylo"}
@@ -54,7 +54,7 @@ write.tree(phy, file = "", append = FALSE,
 
 \author{Emmanuel Paradis, Daniel Lawson
   \email{dan.lawson@bristol.ac.uk}, and Klaus Schliep
-  \email{kschliep@snv.jussieu.fr}}
+  \email{klaus.schliep@gmail.com}}
 \seealso{
   \code{\link{read.tree}}, \code{\link{read.nexus}},
   \code{\link{write.nexus}}, \code{\link{write.phyloXML}}


### PR DESCRIPTION
Hello @emmanuelparadis, 
some improvements to `write.tree` and `write.nexus`.  
The argument `digits` now prints no branch lengths for values smaller zero. I also added the digits argument to `write.nexus`.
Especially for bootstrap or MCMC trees the file size can be much smaller  (`write.nexus(x, digits=-1)`), 
if edge lengths are not needed and tip labels are long but identical for all trees.   

Old behavior:
```
> tree <- rtree(5)
> write.tree(tree)
[1] "((t5:0.1906843837,t4:0.7397239814):0.8904428275,(t1:0.597985581,(t3:0.4325365499,t2:0.1122146):0.5581729759):0.290666458);"
> write.tree(tree, digits=0)
[1] "((t5:0.2,t4:0.7):0.9,(t1:0.6,(t3:0.4,t2:0.1):0.6):0.3);"
> write.tree(tree, digits=-1)
[1] "((t5:%.0-1g,t4:%.0-1g):%.0-1g,(t1:%.0-1g,(t3:%.0-1g,t2:%.0-1g):%.0-1g):%.0-1g);"
> write.tree(tree, digits=-10)
[1] "((t5:%.0-10g,t4:%.0-10g):%.0-10g,(t1:%.0-10g,(t3:%.0-10g,t2:%.0-10g):%.0-10g):%.0-10g);"
```
New behavior:
```
> write.tree(tree)
[1] "((t5:0.1906843837,t4:0.7397239814):0.8904428275,(t1:0.597985581,(t3:0.4325365499,t2:0.1122146):0.5581729759):0.290666458);"
> write.tree(tree, digits = 0)
[1] "((t5:0.2,t4:0.7):0.9,(t1:0.6,(t3:0.4,t2:0.1):0.6):0.3);"
> write.tree(tree, digits = -1)
[1] "((t5,t4),(t1,(t3,t2)));"
> write.tree(tree, digits = -10)
[1] "((t5,t4),(t1,(t3,t2)));"
```


Cheers, 
Klaus